### PR TITLE
feat: add direct messaging between users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,7 @@ FodyWeavers.xsd
 
 # iOS / Swift Package Manager
 mobile/ios/App/CapApp-SPM/Package.resolved
+
+# macOS
+.DS_Store
+

--- a/hono/app.tsx
+++ b/hono/app.tsx
@@ -5,6 +5,7 @@ import { CookieStore, sessionMiddleware } from "hono-sessions";
 import { requireWorkspaceMember } from "./auth/requireWorkspaceMember.js";
 import { auth } from "./routes/auth.js";
 import { channelsRoute } from "./routes/channels.js";
+import { directMessagesRoute } from "./routes/directMessages.js";
 import { emailAuth } from "./routes/emailAuth.js";
 import { health } from "./routes/health.js";
 import { index } from "./routes/index.js";
@@ -67,6 +68,7 @@ export function createApp(options?: AppOptions) {
   app.use("/w/:slug", requireWorkspaceMember);
 
   app.route("/", channelsRoute);
+  app.route("/", directMessagesRoute);
   app.route("/", messagesRoute);
   app.route("/", uploadsRoute);
   app.route("/", createWsRoute());

--- a/hono/components/ChatPage.css
+++ b/hono/components/ChatPage.css
@@ -764,6 +764,83 @@ body {
   cursor: not-allowed;
 }
 
+/* DM list */
+.dm-list {
+  margin-bottom: 8px;
+}
+
+.dm-item {
+  display: flex;
+  align-items: center;
+  padding: 4px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #ababad;
+  border-radius: 4px;
+  margin: 0 8px;
+}
+
+.dm-item:hover {
+  background-color: #35373b;
+  color: #fff;
+}
+
+.dm-item.active {
+  background-color: #1164a3;
+  color: #fff;
+}
+
+.dm-item-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* DM compose modal member list */
+.dm-member-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.dm-member-item {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #d1d2d3;
+  border-radius: 4px;
+}
+
+.dm-member-item:hover {
+  background-color: #35373b;
+  color: #fff;
+}
+
+.dm-member-item-name {
+  font-weight: 600;
+  margin-right: 8px;
+}
+
+.dm-member-item-email {
+  font-size: 12px;
+  color: #ababad;
+}
+
+/* Member item clickable for DM */
+.member-item.dm-clickable {
+  cursor: pointer;
+}
+
+.member-item.dm-clickable:hover {
+  background-color: #35373b;
+  color: #fff;
+}
+
 /* Safe area insets for notch/Dynamic Island devices */
 @supports (padding: env(safe-area-inset-top)) {
   .sidebar {

--- a/hono/components/ChatPage.tsx
+++ b/hono/components/ChatPage.tsx
@@ -52,6 +52,19 @@ export async function ChatPage(wsUrl?: string, user?: User, workspace?: Workspac
               <span>Browse</span>
             </div>
             <ul id="browseChannelList" className="channel-list browse-list"></ul>
+            <div className="sidebar-section-header">
+              <span>Direct Messages</span>
+              <button
+                type="button"
+                id="dmComposeButton"
+                className="create-channel-button"
+                title="New direct message"
+                aria-label="New direct message"
+              >
+                +
+              </button>
+            </div>
+            <ul id="dmList" className="channel-list dm-list"></ul>
             <div className="sidebar-user">
               {user?.picture && <img src={user.picture} alt="Profile" className="profile-picture" />}
               <span className="user-email">{user?.email}</span>
@@ -191,6 +204,20 @@ export async function ChatPage(wsUrl?: string, user?: User, workspace?: Workspac
                 Create
               </button>
             </div>
+          </div>
+        </div>
+
+        <div
+          id="dmComposeModal"
+          className="modal hidden"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="dmComposeTitle"
+        >
+          <div className="modal-content">
+            <h3 id="dmComposeTitle">New Direct Message</h3>
+            <input type="text" id="dmSearchInput" placeholder="Search members..." />
+            <ul id="dmMemberList" className="dm-member-list"></ul>
           </div>
         </div>
 

--- a/hono/db/migrations/0004_messy_silver_centurion.sql
+++ b/hono/db/migrations/0004_messy_silver_centurion.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `direct_conversations` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`workspace_id` integer NOT NULL,
+	`user1_email` text NOT NULL,
+	`user2_email` text NOT NULL,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `direct_conversations_workspace_users_unique` ON `direct_conversations` (`workspace_id`,`user1_email`,`user2_email`);--> statement-breakpoint
+CREATE TABLE `direct_messages` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`content` text NOT NULL,
+	`user_email` text NOT NULL,
+	`user_name` text,
+	`conversation_id` integer NOT NULL,
+	`attachment_key` text,
+	`attachment_name` text,
+	`attachment_type` text,
+	`attachment_size` integer,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`conversation_id`) REFERENCES `direct_conversations`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `direct_messages_created_at_idx` ON `direct_messages` (`created_at`);--> statement-breakpoint
+CREATE INDEX `direct_messages_conversation_id_created_at_idx` ON `direct_messages` (`conversation_id`,`created_at`);

--- a/hono/db/migrations/meta/0004_snapshot.json
+++ b/hono/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,776 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8a99a884-6ca5-4a76-90dc-7e002867df1b",
+  "prevId": "84cc1c85-a0d0-42ab-a12a-8b661201f730",
+  "tables": {
+    "channel_members": {
+      "name": "channel_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "channel_members_channel_id_user_email_unique": {
+          "name": "channel_members_channel_id_user_email_unique",
+          "columns": [
+            "channel_id",
+            "user_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_members_channel_id_channels_id_fk": {
+          "name": "channel_members_channel_id_channels_id_fk",
+          "tableFrom": "channel_members",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "channels_workspace_id_name_unique": {
+          "name": "channels_workspace_id_name_unique",
+          "columns": [
+            "workspace_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channels_workspace_id_workspaces_id_fk": {
+          "name": "channels_workspace_id_workspaces_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "direct_conversations": {
+      "name": "direct_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user1_email": {
+          "name": "user1_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user2_email": {
+          "name": "user2_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "direct_conversations_workspace_users_unique": {
+          "name": "direct_conversations_workspace_users_unique",
+          "columns": [
+            "workspace_id",
+            "user1_email",
+            "user2_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "direct_conversations_workspace_id_workspaces_id_fk": {
+          "name": "direct_conversations_workspace_id_workspaces_id_fk",
+          "tableFrom": "direct_conversations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "direct_messages": {
+      "name": "direct_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachment_key": {
+          "name": "attachment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_name": {
+          "name": "attachment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_size": {
+          "name": "attachment_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "direct_messages_conversation_id_created_at_idx": {
+          "name": "direct_messages_conversation_id_created_at_idx",
+          "columns": [
+            "conversation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversation_id_direct_conversations_id_fk": {
+          "name": "direct_messages_conversation_id_direct_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachment_key": {
+          "name": "attachment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_name": {
+          "name": "attachment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_size": {
+          "name": "attachment_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "messages_created_at_idx": {
+          "name": "messages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "messages_channel_id_created_at_idx": {
+          "name": "messages_channel_id_created_at_idx",
+          "columns": [
+            "channel_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_channel_id_channels_id_fk": {
+          "name": "messages_channel_id_channels_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_registrations": {
+      "name": "pending_registrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "pending_registrations_email_unique": {
+          "name": "pending_registrations_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "pending_registrations_expires_at_index": {
+          "name": "pending_registrations_expires_at_index",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_invites": {
+      "name": "workspace_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "workspace_invites_code_unique": {
+          "name": "workspace_invites_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "workspace_invites_expires_at_idx": {
+          "name": "workspace_invites_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_invites_workspace_id_workspaces_id_fk": {
+          "name": "workspace_invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_invites",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_members": {
+      "name": "workspace_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "workspace_members_workspace_id_user_email_unique": {
+          "name": "workspace_members_workspace_id_user_email_unique",
+          "columns": [
+            "workspace_id",
+            "user_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/hono/db/migrations/meta/_journal.json
+++ b/hono/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775706595927,
       "tag": "0003_nosy_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1775736732300,
+      "tag": "0004_messy_silver_centurion",
+      "breakpoints": true
     }
   ]
 }

--- a/hono/db/schema.ts
+++ b/hono/db/schema.ts
@@ -87,6 +87,48 @@ export const messages = sqliteTable(
   ],
 );
 
+export const directConversations = sqliteTable(
+  "direct_conversations",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    workspaceId: integer("workspace_id")
+      .notNull()
+      .references(() => workspaces.id),
+    user1Email: text("user1_email").notNull(),
+    user2Email: text("user2_email").notNull(),
+    createdAt: text("created_at").default(sql`(CURRENT_TIMESTAMP)`),
+  },
+  (table) => [
+    uniqueIndex("direct_conversations_workspace_users_unique").on(
+      table.workspaceId,
+      table.user1Email,
+      table.user2Email,
+    ),
+  ],
+);
+
+export const directMessages = sqliteTable(
+  "direct_messages",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    content: text("content").notNull(),
+    userEmail: text("user_email").notNull(),
+    userName: text("user_name"),
+    conversationId: integer("conversation_id")
+      .notNull()
+      .references(() => directConversations.id),
+    attachmentKey: text("attachment_key"),
+    attachmentName: text("attachment_name"),
+    attachmentType: text("attachment_type"),
+    attachmentSize: integer("attachment_size"),
+    createdAt: text("created_at").default(sql`(CURRENT_TIMESTAMP)`),
+  },
+  (table) => [
+    index("direct_messages_created_at_idx").on(table.createdAt),
+    index("direct_messages_conversation_id_created_at_idx").on(table.conversationId, table.createdAt),
+  ],
+);
+
 export const users = sqliteTable("users", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   email: text("email").notNull().unique(),

--- a/hono/durableObjects/ChatRoom.ts
+++ b/hono/durableObjects/ChatRoom.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
-import { and, eq } from "drizzle-orm";
-import { channelMembers, getDb, messages } from "../db/index.js";
+import { and, eq, or } from "drizzle-orm";
+import { channelMembers, directConversations, directMessages, getDb, messages } from "../db/index.js";
 import type { Bindings } from "../types.js";
 
 type SessionAttachment = {
@@ -11,6 +11,16 @@ type SessionAttachment = {
 type IncomingMessage = {
   type: string;
   channelId: number;
+  content: string;
+  attachmentKey?: string;
+  attachmentName?: string;
+  attachmentType?: string;
+  attachmentSize?: number;
+};
+
+type IncomingDm = {
+  type: string;
+  conversationId: number;
   content: string;
   attachmentKey?: string;
   attachmentName?: string;
@@ -59,7 +69,7 @@ export class ChatRoom extends DurableObject<Bindings> {
 
     const rawStr = typeof message === "string" ? message : new TextDecoder().decode(message);
 
-    let parsed: IncomingMessage | MembershipEvent;
+    let parsed: IncomingMessage | IncomingDm | MembershipEvent;
     try {
       parsed = JSON.parse(rawStr);
     } catch {
@@ -68,6 +78,11 @@ export class ChatRoom extends DurableObject<Bindings> {
 
     if (parsed.type === "memberJoin" || parsed.type === "memberLeave") {
       await this.handleMembershipEvent(parsed as MembershipEvent);
+      return;
+    }
+
+    if (parsed.type === "dm") {
+      await this.handleDirectMessage(ws, attachment, parsed as IncomingDm);
       return;
     }
 
@@ -145,6 +160,90 @@ export class ChatRoom extends DurableObject<Bindings> {
       }
     } catch (error) {
       console.error("Error broadcasting message:", error);
+    }
+  }
+
+  private async handleDirectMessage(ws: WebSocket, sender: SessionAttachment, dm: IncomingDm): Promise<void> {
+    if (!dm.conversationId) {
+      return;
+    }
+
+    const hasContent = Boolean(dm.content?.trim());
+    const hasAttachment = Boolean(dm.attachmentKey);
+    if (!hasContent && !hasAttachment) {
+      return;
+    }
+
+    const trimmedContent = dm.content?.trim() || "";
+    const db = getDb(this.env.DB);
+
+    const conversation = await db
+      .select()
+      .from(directConversations)
+      .where(
+        and(
+          eq(directConversations.id, dm.conversationId),
+          or(
+            eq(directConversations.user1Email, sender.userEmail),
+            eq(directConversations.user2Email, sender.userEmail),
+          ),
+        ),
+      );
+
+    if (conversation.length === 0) {
+      try {
+        ws.send(JSON.stringify({ type: "error", error: "Not a participant in this conversation" }));
+      } catch {
+        // Socket may be closed
+      }
+      return;
+    }
+
+    const conv = conversation[0];
+
+    try {
+      await db.insert(directMessages).values({
+        content: trimmedContent,
+        userEmail: sender.userEmail,
+        userName: sender.userName,
+        conversationId: dm.conversationId,
+        attachmentKey: dm.attachmentKey || null,
+        attachmentName: dm.attachmentName || null,
+        attachmentType: dm.attachmentType || null,
+        attachmentSize: dm.attachmentSize || null,
+      });
+    } catch (error) {
+      console.error("Error saving DM to database:", error);
+    }
+
+    const outgoing = JSON.stringify({
+      type: "dm",
+      conversationId: dm.conversationId,
+      content: trimmedContent,
+      userName: sender.userName,
+      userEmail: sender.userEmail,
+      attachmentKey: dm.attachmentKey || null,
+      attachmentName: dm.attachmentName || null,
+      attachmentType: dm.attachmentType || null,
+      attachmentSize: dm.attachmentSize || null,
+    });
+
+    try {
+      const participantEmails = new Set([conv.user1Email, conv.user2Email]);
+      const allSockets = this.ctx.getWebSockets();
+
+      for (const socket of allSockets) {
+        const socketAttachment = socket.deserializeAttachment() as SessionAttachment | null;
+        if (socketAttachment && participantEmails.has(socketAttachment.userEmail)) {
+          try {
+            socket.send(outgoing);
+          } catch {
+            // Socket may have been closed between iteration and send
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error broadcasting DM:", error);
     }
   }
 

--- a/hono/routes/directMessages.test.ts
+++ b/hono/routes/directMessages.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestApp } from "../testApp.js";
+
+const mockSelect = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    select: (...args: unknown[]) => mockSelect(...args),
+    insert: (...args: unknown[]) => mockInsert(...args),
+  }),
+  directConversations: {
+    id: "id",
+    workspaceId: "workspace_id",
+    user1Email: "user1_email",
+    user2Email: "user2_email",
+  },
+  directMessages: {
+    conversationId: "conversation_id",
+    createdAt: "created_at",
+  },
+  users: { email: "email", name: "name" },
+  workspaces: { id: "id", slug: "slug" },
+  workspaceMembers: { workspaceId: "workspace_id", userEmail: "user_email" },
+}));
+
+const authenticatedUser = { email: "alice@example.com", name: "Alice", picture: "alice.jpg" };
+
+const mockWorkspace = { id: 1, name: "Default", slug: "default", createdByEmail: "system", createdAt: "2025-01-01" };
+const mockWorkspaceMember = {
+  id: 1,
+  workspaceId: 1,
+  userEmail: "alice@example.com",
+  role: "member",
+  joinedAt: "2025-01-01",
+};
+
+function setupWorkspaceMocks() {
+  mockSelect.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([mockWorkspace]),
+    }),
+  });
+  mockSelect.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([mockWorkspaceMember]),
+    }),
+  });
+}
+
+describe("DM Conversations API", () => {
+  describe("GET /w/:slug/api/dm/conversations", () => {
+    it("should return empty conversations for a new user", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations");
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as { conversations: unknown[] };
+      expect(body.conversations).toEqual([]);
+    });
+
+    it("should return conversations with other user names", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              workspaceId: 1,
+              user1Email: "alice@example.com",
+              user2Email: "bob@example.com",
+              createdAt: "2025-01-01",
+            },
+          ]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ email: "bob@example.com", name: "Bob" }]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations");
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as {
+        conversations: { id: number; otherUserEmail: string; otherUserName: string }[];
+      };
+      expect(body.conversations).toHaveLength(1);
+      expect(body.conversations[0].otherUserEmail).toBe("bob@example.com");
+      expect(body.conversations[0].otherUserName).toBe("Bob");
+    });
+
+    it("should return 401 for unauthenticated user", async () => {
+      const { app } = createTestApp({ authenticatedUser: null });
+      const response = await app.request("/w/default/api/dm/conversations");
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("POST /w/:slug/api/dm/conversations", () => {
+    it("should return 400 when targetEmail is missing", async () => {
+      setupWorkspaceMocks();
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(400);
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("targetEmail is required");
+    });
+
+    it("should return 400 when trying to DM yourself", async () => {
+      setupWorkspaceMocks();
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetEmail: "alice@example.com" }),
+      });
+      expect(response.status).toBe(400);
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Cannot start a DM with yourself");
+    });
+
+    it("should return 404 when target is not a workspace member", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetEmail: "stranger@example.com" }),
+      });
+      expect(response.status).toBe(404);
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("User is not a member of this workspace");
+    });
+
+    it("should return existing conversation if one already exists", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: 1, workspaceId: 1, userEmail: "bob@example.com" }]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: 10,
+              workspaceId: 1,
+              user1Email: "alice@example.com",
+              user2Email: "bob@example.com",
+              createdAt: "2025-01-01",
+            },
+          ]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ name: "Bob" }]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetEmail: "bob@example.com" }),
+      });
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as { conversation: { id: number; otherUserEmail: string } };
+      expect(body.conversation.id).toBe(10);
+      expect(body.conversation.otherUserEmail).toBe("bob@example.com");
+    });
+
+    it("should create a new conversation when none exists", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: 1, workspaceId: 1, userEmail: "bob@example.com" }]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      mockInsert.mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            {
+              id: 20,
+              workspaceId: 1,
+              user1Email: "alice@example.com",
+              user2Email: "bob@example.com",
+              createdAt: "2025-01-01",
+            },
+          ]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ name: "Bob" }]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetEmail: "bob@example.com" }),
+      });
+      expect(response.status).toBe(201);
+
+      const body = (await response.json()) as { conversation: { id: number; otherUserEmail: string } };
+      expect(body.conversation.id).toBe(20);
+      expect(body.conversation.otherUserEmail).toBe("bob@example.com");
+    });
+  });
+
+  describe("GET /w/:slug/api/dm/conversations/:id/messages", () => {
+    it("should return 400 for invalid conversation ID", async () => {
+      setupWorkspaceMocks();
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations/abc/messages");
+      expect(response.status).toBe(400);
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Invalid conversation ID");
+    });
+
+    it("should return 404 when conversation does not exist", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations/999/messages");
+      expect(response.status).toBe(404);
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Conversation not found");
+    });
+
+    it("should return 403 when user is not a participant", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              workspaceId: 1,
+              user1Email: "bob@example.com",
+              user2Email: "carol@example.com",
+              createdAt: "2025-01-01",
+            },
+          ]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations/1/messages");
+      expect(response.status).toBe(403);
+
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("Not a participant in this conversation");
+    });
+
+    it("should return messages for a valid conversation", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            {
+              id: 1,
+              workspaceId: 1,
+              user1Email: "alice@example.com",
+              user2Email: "bob@example.com",
+              createdAt: "2025-01-01",
+            },
+          ]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([
+                {
+                  id: 1,
+                  content: "Hello Bob!",
+                  userEmail: "alice@example.com",
+                  userName: "Alice",
+                  conversationId: 1,
+                  createdAt: "2025-01-01T00:00:00.000Z",
+                },
+              ]),
+            }),
+          }),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/conversations/1/messages");
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as { messages: { content: string }[] };
+      expect(body.messages).toHaveLength(1);
+      expect(body.messages[0].content).toBe("Hello Bob!");
+    });
+  });
+
+  describe("GET /w/:slug/api/dm/workspace-members", () => {
+    it("should return workspace members excluding current user", async () => {
+      setupWorkspaceMocks();
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi
+            .fn()
+            .mockResolvedValue([
+              { userEmail: "alice@example.com" },
+              { userEmail: "bob@example.com" },
+              { userEmail: "carol@example.com" },
+            ]),
+        }),
+      });
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { email: "bob@example.com", name: "Bob" },
+            { email: "carol@example.com", name: "Carol" },
+          ]),
+        }),
+      });
+
+      const { app } = createTestApp({ authenticatedUser });
+      const response = await app.request("/w/default/api/dm/workspace-members");
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as { members: { email: string; name: string }[] };
+      expect(body.members).toHaveLength(2);
+      expect(body.members.every((m) => m.email !== "alice@example.com")).toBe(true);
+    });
+
+    it("should return 401 for unauthenticated user", async () => {
+      const { app } = createTestApp({ authenticatedUser: null });
+      const response = await app.request("/w/default/api/dm/workspace-members");
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/hono/routes/directMessages.ts
+++ b/hono/routes/directMessages.ts
@@ -1,0 +1,207 @@
+import { and, desc, eq, or } from "drizzle-orm";
+import { Hono } from "hono";
+import { directConversations, directMessages, getDb, users, workspaceMembers } from "../db/index.js";
+import type { Env } from "../types.js";
+
+const directMessagesRoute = new Hono<Env>();
+
+directMessagesRoute.get("/w/:slug/api/dm/conversations", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const user = c.get("user");
+    const workspace = c.get("workspace")!;
+
+    const conversations = await db
+      .select()
+      .from(directConversations)
+      .where(
+        and(
+          eq(directConversations.workspaceId, workspace.id),
+          or(eq(directConversations.user1Email, user.email), eq(directConversations.user2Email, user.email)),
+        ),
+      );
+
+    const otherEmails = conversations.map((conv) =>
+      conv.user1Email === user.email ? conv.user2Email : conv.user1Email,
+    );
+
+    const otherUsers =
+      otherEmails.length > 0
+        ? await db
+            .select({ email: users.email, name: users.name })
+            .from(users)
+            .where(or(...otherEmails.map((email) => eq(users.email, email))))
+        : [];
+
+    const userMap = new Map(otherUsers.map((u) => [u.email, u.name]));
+
+    const result = conversations.map((conv) => {
+      const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
+      return {
+        id: conv.id,
+        otherUserEmail: otherEmail,
+        otherUserName: userMap.get(otherEmail) || otherEmail,
+        createdAt: conv.createdAt,
+      };
+    });
+
+    return c.json({ conversations: result });
+  } catch (error) {
+    console.error("Error fetching DM conversations:", error);
+    return c.json({ error: "Failed to fetch conversations" }, 500);
+  }
+});
+
+directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const user = c.get("user");
+    const workspace = c.get("workspace")!;
+
+    const body = await c.req.json();
+    const targetEmail = body.targetEmail?.trim();
+
+    if (!targetEmail) {
+      return c.json({ error: "targetEmail is required" }, 400);
+    }
+
+    if (targetEmail === user.email) {
+      return c.json({ error: "Cannot start a DM with yourself" }, 400);
+    }
+
+    const targetMembership = await db
+      .select()
+      .from(workspaceMembers)
+      .where(and(eq(workspaceMembers.workspaceId, workspace.id), eq(workspaceMembers.userEmail, targetEmail)));
+
+    if (targetMembership.length === 0) {
+      return c.json({ error: "User is not a member of this workspace" }, 404);
+    }
+
+    const [user1Email, user2Email] = user.email < targetEmail ? [user.email, targetEmail] : [targetEmail, user.email];
+
+    const existing = await db
+      .select()
+      .from(directConversations)
+      .where(
+        and(
+          eq(directConversations.workspaceId, workspace.id),
+          eq(directConversations.user1Email, user1Email),
+          eq(directConversations.user2Email, user2Email),
+        ),
+      );
+
+    if (existing.length > 0) {
+      const conv = existing[0];
+      const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
+      const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
+      const otherUserName = targetUser.length > 0 ? targetUser[0].name : otherEmail;
+
+      return c.json({
+        conversation: {
+          id: conv.id,
+          otherUserEmail: otherEmail,
+          otherUserName,
+          createdAt: conv.createdAt,
+        },
+      });
+    }
+
+    const [created] = await db
+      .insert(directConversations)
+      .values({
+        workspaceId: workspace.id,
+        user1Email,
+        user2Email,
+      })
+      .returning();
+
+    const otherEmail = created.user1Email === user.email ? created.user2Email : created.user1Email;
+    const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
+    const otherUserName = targetUser.length > 0 ? targetUser[0].name : otherEmail;
+
+    return c.json(
+      {
+        conversation: {
+          id: created.id,
+          otherUserEmail: otherEmail,
+          otherUserName,
+          createdAt: created.createdAt,
+        },
+      },
+      201,
+    );
+  } catch (error) {
+    console.error("Error creating DM conversation:", error);
+    return c.json({ error: "Failed to create conversation" }, 500);
+  }
+});
+
+directMessagesRoute.get("/w/:slug/api/dm/conversations/:id/messages", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const user = c.get("user");
+    const workspace = c.get("workspace")!;
+
+    const conversationId = Number(c.req.param("id"));
+    if (Number.isNaN(conversationId)) {
+      return c.json({ error: "Invalid conversation ID" }, 400);
+    }
+
+    const conversation = await db
+      .select()
+      .from(directConversations)
+      .where(and(eq(directConversations.id, conversationId), eq(directConversations.workspaceId, workspace.id)));
+
+    if (conversation.length === 0) {
+      return c.json({ error: "Conversation not found" }, 404);
+    }
+
+    const conv = conversation[0];
+    if (conv.user1Email !== user.email && conv.user2Email !== user.email) {
+      return c.json({ error: "Not a participant in this conversation" }, 403);
+    }
+
+    const latestMessages = await db
+      .select()
+      .from(directMessages)
+      .where(eq(directMessages.conversationId, conversationId))
+      .orderBy(desc(directMessages.createdAt))
+      .limit(100);
+
+    return c.json({ messages: latestMessages.reverse() });
+  } catch (error) {
+    console.error("Error fetching DM messages:", error);
+    return c.json({ error: "Failed to fetch messages" }, 500);
+  }
+});
+
+directMessagesRoute.get("/w/:slug/api/dm/workspace-members", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const user = c.get("user");
+    const workspace = c.get("workspace")!;
+
+    const members = await db
+      .select({ userEmail: workspaceMembers.userEmail })
+      .from(workspaceMembers)
+      .where(eq(workspaceMembers.workspaceId, workspace.id));
+
+    const memberEmails = members.map((m) => m.userEmail).filter((email) => email !== user.email);
+
+    const memberUsers =
+      memberEmails.length > 0
+        ? await db
+            .select({ email: users.email, name: users.name })
+            .from(users)
+            .where(or(...memberEmails.map((email) => eq(users.email, email))))
+        : [];
+
+    return c.json({ members: memberUsers });
+  } catch (error) {
+    console.error("Error fetching workspace members:", error);
+    return c.json({ error: "Failed to fetch workspace members" }, 500);
+  }
+});
+
+export { directMessagesRoute };

--- a/hono/routes/directMessages.ts
+++ b/hono/routes/directMessages.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, or } from "drizzle-orm";
+import { and, desc, eq, inArray, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { directConversations, directMessages, getDb, users, workspaceMembers } from "../db/index.js";
 import type { Env } from "../types.js";
@@ -27,10 +27,7 @@ directMessagesRoute.get("/w/:slug/api/dm/conversations", async (c) => {
 
     const otherUsers =
       otherEmails.length > 0
-        ? await db
-            .select({ email: users.email, name: users.name })
-            .from(users)
-            .where(or(...otherEmails.map((email) => eq(users.email, email))))
+        ? await db.select({ email: users.email, name: users.name }).from(users).where(inArray(users.email, otherEmails))
         : [];
 
     const userMap = new Map(otherUsers.map((u) => [u.email, u.name]));
@@ -107,14 +104,46 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
       });
     }
 
-    const [created] = await db
-      .insert(directConversations)
-      .values({
-        workspaceId: workspace.id,
-        user1Email,
-        user2Email,
-      })
-      .returning();
+    let created: (typeof existing)[0];
+    try {
+      [created] = await db
+        .insert(directConversations)
+        .values({
+          workspaceId: workspace.id,
+          user1Email,
+          user2Email,
+        })
+        .returning();
+    } catch (insertError) {
+      const raceExisting = await db
+        .select()
+        .from(directConversations)
+        .where(
+          and(
+            eq(directConversations.workspaceId, workspace.id),
+            eq(directConversations.user1Email, user1Email),
+            eq(directConversations.user2Email, user2Email),
+          ),
+        );
+
+      if (raceExisting.length > 0) {
+        const conv = raceExisting[0];
+        const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
+        const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
+        const otherUserName = targetUser.length > 0 ? targetUser[0].name : otherEmail;
+
+        return c.json({
+          conversation: {
+            id: conv.id,
+            otherUserEmail: otherEmail,
+            otherUserName,
+            createdAt: conv.createdAt,
+          },
+        });
+      }
+
+      throw insertError;
+    }
 
     const otherEmail = created.user1Email === user.email ? created.user2Email : created.user1Email;
     const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
@@ -194,7 +223,7 @@ directMessagesRoute.get("/w/:slug/api/dm/workspace-members", async (c) => {
         ? await db
             .select({ email: users.email, name: users.name })
             .from(users)
-            .where(or(...memberEmails.map((email) => eq(users.email, email))))
+            .where(inArray(users.email, memberEmails))
         : [];
 
     return c.json({ members: memberUsers });

--- a/hono/routes/uploads.test.ts
+++ b/hono/routes/uploads.test.ts
@@ -146,7 +146,7 @@ describe("Upload API endpoint", () => {
     expect(response.status).toBe(400);
 
     const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("channelId is required");
+    expect(body.error).toBe("channelId or conversationId is required");
     expect(mockPut).not.toHaveBeenCalled();
   });
 

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
-import { channelMembers, channels, getDb } from "../db/index.js";
+import { channelMembers, channels, directConversations, getDb } from "../db/index.js";
 import type { Env } from "../types.js";
 
 const MAX_FILE_SIZE = 25 * 1024 * 1024;
@@ -33,18 +33,14 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     const formData = await c.req.formData();
     const file = formData.get("file");
     const channelIdParam = formData.get("channelId");
+    const conversationIdParam = formData.get("conversationId");
 
     if (!file || !(file instanceof File)) {
       return c.json({ error: "No file provided" }, 400);
     }
 
-    if (!channelIdParam) {
-      return c.json({ error: "channelId is required" }, 400);
-    }
-
-    const channelId = Number(channelIdParam);
-    if (!isPositiveInteger(channelId)) {
-      return c.json({ error: "Invalid channelId" }, 400);
+    if (!channelIdParam && !conversationIdParam) {
+      return c.json({ error: "channelId or conversationId is required" }, 400);
     }
 
     if (file.size > MAX_FILE_SIZE) {
@@ -56,27 +52,57 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     }
 
     const db = getDb(c.env.DB);
-
-    const channel = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)))
-      .limit(1);
-    if (channel.length === 0) {
-      return c.json({ error: "Channel not found in this workspace" }, 404);
-    }
-
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)))
-      .limit(1);
-    if (membership.length === 0) {
-      return c.json({ error: "Not a member of this channel" }, 403);
-    }
-
     const ext = getExtension(file.type);
-    const key = `${workspace.slug}/${channelId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+    let key: string;
+
+    if (conversationIdParam) {
+      const conversationId = Number(conversationIdParam);
+      if (!isPositiveInteger(conversationId)) {
+        return c.json({ error: "Invalid conversationId" }, 400);
+      }
+
+      const conversation = await db
+        .select()
+        .from(directConversations)
+        .where(
+          and(
+            eq(directConversations.id, conversationId),
+            eq(directConversations.workspaceId, workspace.id),
+            or(eq(directConversations.user1Email, user.email), eq(directConversations.user2Email, user.email)),
+          ),
+        )
+        .limit(1);
+      if (conversation.length === 0) {
+        return c.json({ error: "Conversation not found" }, 404);
+      }
+
+      key = `${workspace.slug}/dm/${conversationId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+    } else {
+      const channelId = Number(channelIdParam);
+      if (!isPositiveInteger(channelId)) {
+        return c.json({ error: "Invalid channelId" }, 400);
+      }
+
+      const channel = await db
+        .select()
+        .from(channels)
+        .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)))
+        .limit(1);
+      if (channel.length === 0) {
+        return c.json({ error: "Channel not found in this workspace" }, 404);
+      }
+
+      const membership = await db
+        .select()
+        .from(channelMembers)
+        .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)))
+        .limit(1);
+      if (membership.length === 0) {
+        return c.json({ error: "Not a member of this channel" }, 403);
+      }
+
+      key = `${workspace.slug}/${channelId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+    }
 
     await c.env.STORAGE.put(key, file.stream(), {
       httpMetadata: { contentType: file.type },
@@ -111,19 +137,45 @@ uploadsRoute.get("/w/:slug/api/files/*", async (c) => {
       return c.json({ error: "File not found" }, 404);
     }
 
-    const channelId = Number(keyParts[1]);
-    if (!isPositiveInteger(channelId)) {
-      return c.json({ error: "File not found" }, 404);
-    }
-
     const db = getDb(c.env.DB);
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)))
-      .limit(1);
-    if (membership.length === 0) {
-      return c.json({ error: "File not found" }, 404);
+
+    if (keyParts[1] === "dm") {
+      if (keyParts.length < 4) {
+        return c.json({ error: "File not found" }, 404);
+      }
+      const conversationId = Number(keyParts[2]);
+      if (!isPositiveInteger(conversationId)) {
+        return c.json({ error: "File not found" }, 404);
+      }
+
+      const conversation = await db
+        .select()
+        .from(directConversations)
+        .where(
+          and(
+            eq(directConversations.id, conversationId),
+            eq(directConversations.workspaceId, workspace.id),
+            or(eq(directConversations.user1Email, user.email), eq(directConversations.user2Email, user.email)),
+          ),
+        )
+        .limit(1);
+      if (conversation.length === 0) {
+        return c.json({ error: "File not found" }, 404);
+      }
+    } else {
+      const channelId = Number(keyParts[1]);
+      if (!isPositiveInteger(channelId)) {
+        return c.json({ error: "File not found" }, 404);
+      }
+
+      const membership = await db
+        .select()
+        .from(channelMembers)
+        .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)))
+        .limit(1);
+      if (membership.length === 0) {
+        return c.json({ error: "File not found" }, 404);
+      }
     }
 
     const object = await c.env.STORAGE.get(key);

--- a/hono/static/ChatPage.ts
+++ b/hono/static/ChatPage.ts
@@ -69,7 +69,7 @@
     id: number;
     otherUserEmail: string;
     otherUserName: string;
-    createdAt: string;
+    createdAt: string | null;
   };
 
   type ViewMode = "channel" | "dm";

--- a/hono/static/ChatPage.ts
+++ b/hono/static/ChatPage.ts
@@ -28,6 +28,11 @@
   const fileInput = document.getElementById("fileInput") as HTMLInputElement;
   const attachButton = document.getElementById("attachButton") as HTMLButtonElement;
   const attachmentPreview = document.getElementById("attachmentPreview") as HTMLDivElement;
+  const dmListEl = document.getElementById("dmList") as HTMLUListElement;
+  const dmComposeButton = document.getElementById("dmComposeButton") as HTMLButtonElement;
+  const dmComposeModal = document.getElementById("dmComposeModal") as HTMLDivElement;
+  const dmSearchInput = document.getElementById("dmSearchInput") as HTMLInputElement;
+  const dmMemberListEl = document.getElementById("dmMemberList") as HTMLUListElement;
 
   const STATUS_CLASS = "status";
   const CONNECTED_CLASS = "connected";
@@ -60,6 +65,15 @@
     name: string;
   };
 
+  type DmConversation = {
+    id: number;
+    otherUserEmail: string;
+    otherUserName: string;
+    createdAt: string;
+  };
+
+  type ViewMode = "channel" | "dm";
+
   let activeChannelId: number | null = null;
   const myChannelIds: Set<number> = new Set();
   let allChannels: Channel[] = [];
@@ -68,6 +82,10 @@
   let membersPanelVisible = true;
   let pendingFile: File | null = null;
   let isUploading = false;
+  let viewMode: ViewMode = "channel";
+  let activeDmConversationId: number | null = null;
+  let dmConversations: DmConversation[] = [];
+  let allWorkspaceMembers: Member[] = [];
 
   const MOBILE_BREAKPOINT = 768;
   const TABLET_BREAKPOINT = 1024;
@@ -260,8 +278,13 @@
     });
     for (const member of sorted) {
       const li = document.createElement("li");
-      li.className = `member-item${member.email === currentUserEmail ? " current-user" : ""}`;
+      const isDmClickable = member.email !== currentUserEmail && viewMode === "channel";
+      li.className = `member-item${member.email === currentUserEmail ? " current-user" : ""}${isDmClickable ? " dm-clickable" : ""}`;
       li.textContent = member.name;
+      if (isDmClickable) {
+        li.title = `Message ${member.name}`;
+        li.addEventListener("click", () => startDmWithUser(member.email));
+      }
       membersList.appendChild(li);
     }
   }
@@ -275,7 +298,7 @@
 
     for (const ch of myChannels) {
       const li = document.createElement("li");
-      li.className = `channel-item${ch.id === activeChannelId ? " active" : ""}`;
+      li.className = `channel-item${viewMode === "channel" && ch.id === activeChannelId ? " active" : ""}`;
 
       const nameSpan = document.createElement("span");
       nameSpan.className = "channel-item-name";
@@ -316,6 +339,170 @@
     }
   }
 
+  async function fetchDmConversations(): Promise<void> {
+    try {
+      const response = await fetch(`${apiBase}/dm/conversations`);
+      if (response.ok) {
+        const data = (await response.json()) as { conversations?: DmConversation[] };
+        dmConversations = data.conversations || [];
+      }
+    } catch (error) {
+      console.error("Error fetching DM conversations:", error);
+    }
+    renderDmList();
+  }
+
+  function renderDmList(): void {
+    dmListEl.innerHTML = "";
+    for (const conv of dmConversations) {
+      const li = document.createElement("li");
+      li.className = `dm-item${viewMode === "dm" && conv.id === activeDmConversationId ? " active" : ""}`;
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "dm-item-name";
+      nameSpan.textContent = conv.otherUserName;
+      li.appendChild(nameSpan);
+
+      li.addEventListener("click", () => switchToDm(conv.id, conv.otherUserName));
+      dmListEl.appendChild(li);
+    }
+  }
+
+  async function loadDmMessages(conversationId: number): Promise<void> {
+    clearMessages();
+    const controller = new AbortController();
+    const timeoutId = MESSAGES_TIMEOUT_MS > 0 ? setTimeout(() => controller.abort(), MESSAGES_TIMEOUT_MS) : undefined;
+    try {
+      const response = await fetch(`${apiBase}/dm/conversations/${conversationId}/messages`, {
+        signal: controller.signal,
+      });
+      if (response.ok) {
+        const data = (await response.json()) as { messages?: MessageData[] };
+        if (data.messages) {
+          for (const msg of data.messages) {
+            displayMessage(msg);
+          }
+        }
+      } else {
+        console.error("Failed to load DM messages:", response.status);
+      }
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        console.info("Loading DM messages was aborted (timeout).");
+        return;
+      }
+      console.error("Error loading DM messages:", error);
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  async function switchToDm(conversationId: number, otherUserName: string): Promise<void> {
+    if (viewMode === "dm" && conversationId === activeDmConversationId) {
+      if (isMobileView()) closeSidebar();
+      return;
+    }
+    viewMode = "dm";
+    activeDmConversationId = conversationId;
+    channelNameHeader.textContent = otherUserName;
+    membersPanel.classList.add("hidden");
+    toggleMembersButton.classList.add("hidden");
+    renderChannelLists();
+    renderDmList();
+    if (isMobileView()) closeSidebar();
+    await loadDmMessages(conversationId);
+    messageInput.focus();
+  }
+
+  function switchBackToChannel(): void {
+    viewMode = "channel";
+    activeDmConversationId = null;
+    toggleMembersButton.classList.remove("hidden");
+    if (membersPanelVisible) {
+      membersPanel.classList.remove("hidden");
+    }
+    renderDmList();
+  }
+
+  async function openDmCompose(): Promise<void> {
+    dmComposeModal.classList.remove("hidden");
+    dmSearchInput.value = "";
+    dmSearchInput.focus();
+
+    try {
+      const response = await fetch(`${apiBase}/dm/workspace-members`);
+      if (response.ok) {
+        const data = (await response.json()) as { members?: Member[] };
+        allWorkspaceMembers = data.members || [];
+      }
+    } catch (error) {
+      console.error("Error fetching workspace members for DM compose:", error);
+    }
+
+    renderDmMemberList("");
+  }
+
+  function closeDmCompose(): void {
+    dmComposeModal.classList.add("hidden");
+  }
+
+  function renderDmMemberList(filter: string): void {
+    dmMemberListEl.innerHTML = "";
+    const lowerFilter = filter.toLowerCase();
+    const filtered = allWorkspaceMembers.filter(
+      (m) => m.name.toLowerCase().includes(lowerFilter) || m.email.toLowerCase().includes(lowerFilter),
+    );
+
+    for (const member of filtered) {
+      const li = document.createElement("li");
+      li.className = "dm-member-item";
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "dm-member-item-name";
+      nameSpan.textContent = member.name;
+      li.appendChild(nameSpan);
+
+      const emailSpan = document.createElement("span");
+      emailSpan.className = "dm-member-item-email";
+      emailSpan.textContent = member.email;
+      li.appendChild(emailSpan);
+
+      li.addEventListener("click", () => {
+        closeDmCompose();
+        startDmWithUser(member.email);
+      });
+      dmMemberListEl.appendChild(li);
+    }
+  }
+
+  async function startDmWithUser(targetEmail: string): Promise<void> {
+    try {
+      const response = await fetch(`${apiBase}/dm/conversations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetEmail }),
+      });
+      if (response.ok || response.status === 201) {
+        const data = (await response.json()) as { conversation: DmConversation };
+        const conv = data.conversation;
+
+        const existingIndex = dmConversations.findIndex((c) => c.id === conv.id);
+        if (existingIndex === -1) {
+          dmConversations.unshift(conv);
+        }
+
+        await switchToDm(conv.id, conv.otherUserName);
+      } else {
+        const data = (await response.json()) as { error?: string };
+        console.error("Error starting DM:", data.error);
+      }
+    } catch (error) {
+      console.error("Error starting DM:", error);
+    }
+  }
+
   async function initChannels(): Promise<void> {
     await fetchMemberships();
 
@@ -332,6 +519,7 @@
     }
 
     renderChannelLists();
+    await fetchDmConversations();
 
     if (activeChannelId) {
       await loadMessagesForChannel(activeChannelId);
@@ -340,13 +528,17 @@
   }
 
   async function switchChannel(channelId: number, channelName: string): Promise<void> {
-    if (channelId === activeChannelId) {
+    if (viewMode === "channel" && channelId === activeChannelId) {
       if (isMobileView()) closeSidebar();
       return;
+    }
+    if (viewMode === "dm") {
+      switchBackToChannel();
     }
     activeChannelId = channelId;
     channelNameHeader.textContent = `#${channelName}`;
     renderChannelLists();
+    renderDmList();
     if (isMobileView()) closeSidebar();
     await loadMessagesForChannel(channelId);
     await fetchChannelMembers(channelId);
@@ -458,6 +650,18 @@
         createChannelModal.classList.add("hidden");
         createChannel(name);
       }
+    }
+  });
+
+  dmComposeButton.addEventListener("click", () => openDmCompose());
+
+  dmSearchInput.addEventListener("input", () => {
+    renderDmMemberList(dmSearchInput.value.trim());
+  });
+
+  dmComposeModal.addEventListener("click", (e: MouseEvent) => {
+    if (e.target === dmComposeModal) {
+      closeDmCompose();
     }
   });
 
@@ -593,6 +797,8 @@
     if (e.key === "Escape") {
       if (sidebar.classList.contains("open")) {
         closeSidebar();
+      } else if (!dmComposeModal.classList.contains("hidden")) {
+        closeDmCompose();
       } else if (!createWorkspaceModal.classList.contains("hidden")) {
         closeWorkspaceModal();
       } else if (!createChannelModal.classList.contains("hidden")) {
@@ -654,7 +860,8 @@
       try {
         const data = JSON.parse(event.data as string) as {
           type: string;
-          channelId: number;
+          channelId?: number;
+          conversationId?: number;
           userName?: string;
           userEmail: string;
           content: string;
@@ -663,8 +870,17 @@
           attachmentType?: string | null;
           attachmentSize?: number | null;
         };
-        if (data.type === "message" && data.channelId === activeChannelId) {
+        if (data.type === "message" && viewMode === "channel" && data.channelId === activeChannelId) {
           displayMessage(data);
+        }
+        if (data.type === "dm" && viewMode === "dm" && data.conversationId === activeDmConversationId) {
+          displayMessage(data);
+        }
+        if (data.type === "dm") {
+          const existingConv = dmConversations.find((c) => c.id === data.conversationId);
+          if (!existingConv) {
+            fetchDmConversations();
+          }
         }
         if ((data.type === "memberJoin" || data.type === "memberLeave") && data.channelId === activeChannelId) {
           fetchChannelMembers(data.channelId);
@@ -772,7 +988,11 @@
   async function uploadFile(file: File): Promise<{ key: string; name: string; type: string; size: number } | null> {
     const formData = new FormData();
     formData.append("file", file);
-    formData.append("channelId", String(activeChannelId));
+    if (viewMode === "dm" && activeDmConversationId !== null) {
+      formData.append("conversationId", String(activeDmConversationId));
+    } else {
+      formData.append("channelId", String(activeChannelId));
+    }
 
     try {
       const response = await fetch(`${apiBase}/upload`, {
@@ -798,17 +1018,18 @@
     const hasMessage = Boolean(message);
     const hasFile = Boolean(pendingFile);
 
-    if ((!hasMessage && !hasFile) || ws.readyState !== WebSocket.OPEN || activeChannelId === null) {
-      return;
-    }
+    if (!hasMessage && !hasFile) return;
+    if (ws.readyState !== WebSocket.OPEN) return;
+
+    if (viewMode === "channel" && activeChannelId === null) return;
+    if (viewMode === "dm" && activeDmConversationId === null) return;
 
     if (isUploading) return;
 
-    const wsPayload: Record<string, unknown> = {
-      type: "message",
-      channelId: activeChannelId,
-      content: message,
-    };
+    const wsPayload: Record<string, unknown> =
+      viewMode === "channel"
+        ? { type: "message", channelId: activeChannelId, content: message }
+        : { type: "dm", conversationId: activeDmConversationId, content: message };
 
     if (hasFile && pendingFile) {
       isUploading = true;

--- a/hono/types.ts
+++ b/hono/types.ts
@@ -30,6 +30,14 @@ export type Channel = {
   createdAt: string | null;
 };
 
+export type DirectConversation = {
+  id: number;
+  workspaceId: number;
+  user1Email: string;
+  user2Email: string;
+  createdAt: string | null;
+};
+
 export type Bindings = {
   DB: D1Database;
   STORAGE: R2Bucket;


### PR DESCRIPTION
## Summary

- Add pair-based direct messaging (DM) between users with real-time WebSocket delivery
- Implement DM sidebar section, compose modal for starting new conversations, and file attachment support
- Add dedicated `directConversations` and `directMessages` database tables (not reusing channels)

## Details

### Database
- New `directConversations` table with canonical participant ordering (`user1_email < user2_email`)
- New `directMessages` table linked to conversations with sender info and optional file attachments
- Migration: `0004_messy_silver_centurion.sql`

### API Routes (`hono/routes/directMessages.ts`)
- `GET /w/:slug/api/dm/conversations` — list user's DM conversations
- `POST /w/:slug/api/dm/conversations` — create or retrieve a conversation with a target user (handles concurrent creation gracefully)
- `GET /w/:slug/api/dm/conversations/:id/messages` — fetch latest 100 DM messages
- `GET /w/:slug/api/dm/workspace-members` — list workspace members for the compose picker

### Real-time (Durable Object)
- Extended `ChatRoom` to handle `type: "dm"` WebSocket messages
- DM messages are persisted to D1 and broadcast to both participants in real-time

### Uploads
- Extended upload/download routes to support DM file attachments (`conversationId` param)
- R2 key pattern: `<slug>/dm/<conversationId>/<filename>`
- Access validation ensures only conversation participants can upload/download DM files

### UI
- DM sidebar section below Channels with conversation list and "+" compose button
- Compose modal with member search/filter for starting new conversations
- Click a member name in the members panel to start a DM
- View mode switching between channel and DM contexts

### Tests
- 14 new unit tests for DM route handlers (`directMessages.test.ts`)
- Updated `uploads.test.ts` for new error message
- All 167 tests pass, lint clean, build succeeds