### PR TITLE
feat: add audio huddle support for DM conversations

### DIFF
--- a/hono/components/ChatPage.css
+++ b/hono/components/ChatPage.css
@@ -841,6 +841,200 @@ body {
   color: #fff;
 }
 
+/* Huddle: Start button in header */
+.start-huddle-button {
+  background: none;
+  border: 1px solid #ababad;
+  color: #ababad;
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+.start-huddle-button:hover {
+  background-color: #35373b;
+  color: #fff;
+  border-color: #fff;
+}
+
+.start-huddle-button.hidden {
+  display: none;
+}
+
+/* Huddle: Incoming call banner */
+.huddle-incoming-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background-color: #1164a3;
+  color: #fff;
+  font-size: 14px;
+  animation: huddle-pulse 2s ease-in-out infinite;
+}
+
+.huddle-incoming-banner.hidden {
+  display: none;
+}
+
+@keyframes huddle-pulse {
+  0%, 100% { background-color: #1164a3; }
+  50% { background-color: #0d5289; }
+}
+
+.huddle-incoming-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.huddle-caller-name {
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.huddle-incoming-label {
+  white-space: nowrap;
+}
+
+.huddle-incoming-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.huddle-accept-button {
+  padding: 6px 14px;
+  background-color: #007a5a;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.huddle-accept-button:hover {
+  background-color: #005e46;
+}
+
+.huddle-decline-button {
+  padding: 6px 14px;
+  background-color: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.huddle-decline-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: #fff;
+}
+
+/* Huddle: Active bar */
+.huddle-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 20px;
+  background-color: #0d2e25;
+  border-bottom: 1px solid #007a5a;
+  font-size: 13px;
+}
+
+.huddle-bar.hidden {
+  display: none;
+}
+
+.huddle-bar-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.huddle-bar-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #007a5a;
+  flex-shrink: 0;
+  animation: huddle-blink 1.5s ease-in-out infinite;
+}
+
+@keyframes huddle-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.huddle-bar-status {
+  color: #007a5a;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.huddle-bar-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.huddle-control-button {
+  background: none;
+  border: 1px solid #ababad;
+  color: #ababad;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 28px;
+}
+
+.huddle-control-button:hover {
+  background-color: #35373b;
+  color: #fff;
+  border-color: #fff;
+}
+
+.huddle-control-button.muted {
+  background-color: #e0143c;
+  border-color: #e0143c;
+  color: #fff;
+}
+
+.huddle-end-button {
+  width: auto;
+  padding: 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #e0143c;
+  border-color: #e0143c;
+}
+
+.huddle-end-button:hover {
+  background-color: #e0143c;
+  color: #fff;
+  border-color: #e0143c;
+}
+
 /* Safe area insets for notch/Dynamic Island devices */
 @supports (padding: env(safe-area-inset-top)) {
   .sidebar {

--- a/hono/components/ChatPage.test.ts
+++ b/hono/components/ChatPage.test.ts
@@ -136,4 +136,59 @@ describe("ChatPage component", () => {
     expect(html).toContain('id="createWorkspaceError"');
     expect(html).toContain("modal-error hidden");
   });
+
+  it("should include start huddle button hidden by default", async () => {
+    const jsxElement = await ChatPage();
+
+    const html = jsxElement.toString();
+    expect(html).toContain('id="startHuddleButton"');
+    expect(html).toContain("start-huddle-button hidden");
+    expect(html).toContain('title="Start a huddle"');
+  });
+
+  it("should include huddle incoming call banner hidden by default", async () => {
+    const jsxElement = await ChatPage();
+
+    const html = jsxElement.toString();
+    expect(html).toContain('id="huddleIncomingBanner"');
+    expect(html).toContain("huddle-incoming-banner hidden");
+    expect(html).toContain('id="huddleCallerName"');
+    expect(html).toContain("is starting a huddle");
+  });
+
+  it("should include huddle accept and decline buttons", async () => {
+    const jsxElement = await ChatPage();
+
+    const html = jsxElement.toString();
+    expect(html).toContain('id="huddleAcceptButton"');
+    expect(html).toContain("huddle-accept-button");
+    expect(html).toContain('id="huddleDeclineButton"');
+    expect(html).toContain("huddle-decline-button");
+  });
+
+  it("should include huddle bar hidden by default", async () => {
+    const jsxElement = await ChatPage();
+
+    const html = jsxElement.toString();
+    expect(html).toContain('id="huddleBar"');
+    expect(html).toContain("huddle-bar hidden");
+    expect(html).toContain('id="huddleStatus"');
+  });
+
+  it("should include huddle mute and end buttons", async () => {
+    const jsxElement = await ChatPage();
+
+    const html = jsxElement.toString();
+    expect(html).toContain('id="huddleMuteButton"');
+    expect(html).toContain('id="huddleEndButton"');
+    expect(html).toContain("huddle-end-button");
+  });
+
+  it("should include remote audio element for huddle", async () => {
+    const jsxElement = await ChatPage();
+
+    const html = jsxElement.toString();
+    expect(html).toContain('id="remoteAudio"');
+    expect(html).toContain("autoplay");
+  });
 });

--- a/hono/components/ChatPage.tsx
+++ b/hono/components/ChatPage.tsx
@@ -150,7 +150,14 @@ export async function ChatPage(wsUrl?: string, user?: User, workspace?: Workspac
                 </span>
               </div>
               <div className="huddle-bar-controls">
-                <button type="button" id="huddleMuteButton" className="huddle-control-button" title="Toggle mute">
+                <button
+                  type="button"
+                  id="huddleMuteButton"
+                  className="huddle-control-button"
+                  title="Toggle mute"
+                  aria-label="Toggle mute"
+                  aria-pressed="false"
+                >
                   <svg
                     id="huddleMuteIcon"
                     width="16"
@@ -178,9 +185,8 @@ export async function ChatPage(wsUrl?: string, user?: User, workspace?: Workspac
                   End
                 </button>
               </div>
-              <audio id="remoteAudio" autoplay={true}>
-                <track kind="captions" default={false} />
-              </audio>
+              {/* biome-ignore lint/a11y/useMediaCaption: audio-only huddle stream has no captions */}
+              <audio id="remoteAudio" autoplay={true} />
             </div>
             <div id="status" className="status disconnected">
               Connecting to {wsUrl}...

--- a/hono/components/ChatPage.tsx
+++ b/hono/components/ChatPage.tsx
@@ -97,6 +97,27 @@ export async function ChatPage(wsUrl?: string, user?: User, workspace?: Workspac
                 <h2 id="channelName">#general</h2>
                 <button
                   type="button"
+                  id="startHuddleButton"
+                  className="start-huddle-button hidden"
+                  title="Start a huddle"
+                  aria-label="Start a huddle"
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    role="img"
+                    aria-label="Huddle"
+                  >
+                    <title>Huddle</title>
+                    <path d="M15.05 5A5 5 0 0 1 19 8.95M15.05 1A9 9 0 0 1 23 8.94M1 15.42V21a1 1 0 0 0 1 1h5.58a2 2 0 0 0 1.45-.63l8.58-9.59a2 2 0 0 0-.04-2.72L13.2 4.52a2 2 0 0 0-2.72-.04L1.63 13.97a2 2 0 0 0-.63 1.45z" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
                   id="toggleMembersButton"
                   className="toggle-members-button"
                   title="Toggle members panel"
@@ -106,6 +127,60 @@ export async function ChatPage(wsUrl?: string, user?: User, workspace?: Workspac
                   Members
                 </button>
               </div>
+            </div>
+            <div id="huddleIncomingBanner" className="huddle-incoming-banner hidden">
+              <div className="huddle-incoming-info">
+                <span id="huddleCallerName" className="huddle-caller-name"></span>
+                <span className="huddle-incoming-label">is starting a huddle</span>
+              </div>
+              <div className="huddle-incoming-actions">
+                <button type="button" id="huddleAcceptButton" className="huddle-accept-button">
+                  Accept
+                </button>
+                <button type="button" id="huddleDeclineButton" className="huddle-decline-button">
+                  Decline
+                </button>
+              </div>
+            </div>
+            <div id="huddleBar" className="huddle-bar hidden">
+              <div className="huddle-bar-info">
+                <span className="huddle-bar-indicator"></span>
+                <span id="huddleStatus" className="huddle-bar-status">
+                  Huddle
+                </span>
+              </div>
+              <div className="huddle-bar-controls">
+                <button type="button" id="huddleMuteButton" className="huddle-control-button" title="Toggle mute">
+                  <svg
+                    id="huddleMuteIcon"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    role="img"
+                    aria-label="Microphone"
+                  >
+                    <title>Microphone</title>
+                    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+                    <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+                    <line x1="12" y1="19" x2="12" y2="23" />
+                    <line x1="8" y1="23" x2="16" y2="23" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  id="huddleEndButton"
+                  className="huddle-control-button huddle-end-button"
+                  title="End huddle"
+                >
+                  End
+                </button>
+              </div>
+              <audio id="remoteAudio" autoplay={true}>
+                <track kind="captions" default={false} />
+              </audio>
             </div>
             <div id="status" className="status disconnected">
               Connecting to {wsUrl}...

--- a/hono/durableObjects/ChatRoom.ts
+++ b/hono/durableObjects/ChatRoom.ts
@@ -35,6 +35,14 @@ type MembershipEvent = {
   userName: string;
 };
 
+type IncomingHuddleSignal = {
+  type: string;
+  conversationId: number;
+  offer?: RTCSessionDescriptionInit;
+  answer?: RTCSessionDescriptionInit;
+  candidate?: RTCIceCandidateInit;
+};
+
 export class ChatRoom extends DurableObject<Bindings> {
   constructor(ctx: DurableObjectState, env: Bindings) {
     super(ctx, env);
@@ -69,7 +77,7 @@ export class ChatRoom extends DurableObject<Bindings> {
 
     const rawStr = typeof message === "string" ? message : new TextDecoder().decode(message);
 
-    let parsed: IncomingMessage | IncomingDm | MembershipEvent;
+    let parsed: IncomingMessage | IncomingDm | MembershipEvent | IncomingHuddleSignal;
     try {
       parsed = JSON.parse(rawStr);
     } catch {
@@ -83,6 +91,12 @@ export class ChatRoom extends DurableObject<Bindings> {
 
     if (parsed.type === "dm") {
       await this.handleDirectMessage(ws, attachment, parsed as IncomingDm);
+      return;
+    }
+
+    const huddleTypes = new Set(["huddle-offer", "huddle-answer", "huddle-ice-candidate", "huddle-end"]);
+    if (huddleTypes.has(parsed.type)) {
+      await this.handleHuddleSignal(ws, attachment, parsed as IncomingHuddleSignal);
       return;
     }
 
@@ -244,6 +258,69 @@ export class ChatRoom extends DurableObject<Bindings> {
       }
     } catch (error) {
       console.error("Error broadcasting DM:", error);
+    }
+  }
+
+  private async handleHuddleSignal(
+    ws: WebSocket,
+    sender: SessionAttachment,
+    signal: IncomingHuddleSignal,
+  ): Promise<void> {
+    if (!signal.conversationId) {
+      return;
+    }
+
+    if (signal.type === "huddle-offer" && !signal.offer) return;
+    if (signal.type === "huddle-answer" && !signal.answer) return;
+    if (signal.type === "huddle-ice-candidate" && !signal.candidate) return;
+
+    const db = getDb(this.env.DB);
+
+    const conversation = await db
+      .select()
+      .from(directConversations)
+      .where(
+        and(
+          eq(directConversations.id, signal.conversationId),
+          or(
+            eq(directConversations.user1Email, sender.userEmail),
+            eq(directConversations.user2Email, sender.userEmail),
+          ),
+        ),
+      );
+
+    if (conversation.length === 0) {
+      try {
+        ws.send(JSON.stringify({ type: "error", error: "Not a participant in this conversation" }));
+      } catch {
+        // Socket may be closed
+      }
+      return;
+    }
+
+    const conv = conversation[0];
+    const otherEmail = conv.user1Email === sender.userEmail ? conv.user2Email : conv.user1Email;
+
+    const outgoing = JSON.stringify({
+      ...signal,
+      userEmail: sender.userEmail,
+      userName: sender.userName,
+    });
+
+    try {
+      const allSockets = this.ctx.getWebSockets();
+      for (const socket of allSockets) {
+        const socketAttachment = socket.deserializeAttachment() as SessionAttachment | null;
+        if (socketAttachment && socketAttachment.userEmail === otherEmail) {
+          try {
+            socket.send(outgoing);
+          } catch {
+            // Socket may have been closed
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error relaying huddle signal:", error);
     }
   }
 

--- a/hono/durableObjects/ChatRoom.ts
+++ b/hono/durableObjects/ChatRoom.ts
@@ -43,7 +43,11 @@ type IncomingHuddleSignal = {
   candidate?: RTCIceCandidateInit;
 };
 
+const HUDDLE_TYPES = new Set(["huddle-offer", "huddle-answer", "huddle-ice-candidate", "huddle-end"]);
+
 export class ChatRoom extends DurableObject<Bindings> {
+  private dmAuthCache = new Map<string, string>();
+
   constructor(ctx: DurableObjectState, env: Bindings) {
     super(ctx, env);
     this.ctx.setWebSocketAutoResponse(new WebSocketRequestResponsePair("ping", "pong"));
@@ -94,8 +98,7 @@ export class ChatRoom extends DurableObject<Bindings> {
       return;
     }
 
-    const huddleTypes = new Set(["huddle-offer", "huddle-answer", "huddle-ice-candidate", "huddle-end"]);
-    if (huddleTypes.has(parsed.type)) {
+    if (HUDDLE_TYPES.has(parsed.type)) {
       await this.handleHuddleSignal(ws, attachment, parsed as IncomingHuddleSignal);
       return;
     }
@@ -274,32 +277,41 @@ export class ChatRoom extends DurableObject<Bindings> {
     if (signal.type === "huddle-answer" && !signal.answer) return;
     if (signal.type === "huddle-ice-candidate" && !signal.candidate) return;
 
-    const db = getDb(this.env.DB);
+    const cacheKey = `${sender.userEmail}:${signal.conversationId}`;
+    let otherEmail = this.dmAuthCache.get(cacheKey);
 
-    const conversation = await db
-      .select()
-      .from(directConversations)
-      .where(
-        and(
-          eq(directConversations.id, signal.conversationId),
-          or(
-            eq(directConversations.user1Email, sender.userEmail),
-            eq(directConversations.user2Email, sender.userEmail),
+    if (!otherEmail) {
+      const db = getDb(this.env.DB);
+
+      const conversation = await db
+        .select()
+        .from(directConversations)
+        .where(
+          and(
+            eq(directConversations.id, signal.conversationId),
+            or(
+              eq(directConversations.user1Email, sender.userEmail),
+              eq(directConversations.user2Email, sender.userEmail),
+            ),
           ),
-        ),
-      );
+        );
 
-    if (conversation.length === 0) {
-      try {
-        ws.send(JSON.stringify({ type: "error", error: "Not a participant in this conversation" }));
-      } catch {
-        // Socket may be closed
+      if (conversation.length === 0) {
+        try {
+          ws.send(JSON.stringify({ type: "error", error: "Not a participant in this conversation" }));
+        } catch {
+          // Socket may be closed
+        }
+        return;
       }
-      return;
-    }
 
-    const conv = conversation[0];
-    const otherEmail = conv.user1Email === sender.userEmail ? conv.user2Email : conv.user1Email;
+      const conv = conversation[0];
+      otherEmail = conv.user1Email === sender.userEmail ? conv.user2Email : conv.user1Email;
+      if (this.dmAuthCache.size >= 1000) {
+        this.dmAuthCache.clear();
+      }
+      this.dmAuthCache.set(cacheKey, otherEmail);
+    }
 
     const outgoing = JSON.stringify({
       ...signal,

--- a/hono/static/ChatPage.ts
+++ b/hono/static/ChatPage.ts
@@ -629,6 +629,7 @@
     huddleOtherUserName = "";
     huddleMuted = false;
     huddleMuteButton.classList.remove("muted");
+    huddleMuteButton.setAttribute("aria-pressed", "false");
 
     hideHuddleBar();
     hideIncomingBanner();
@@ -749,7 +750,12 @@
 
   async function handleHuddleAnswer(conversationId: number, answer: RTCSessionDescriptionInit): Promise<void> {
     if (!huddlePeerConnection || !huddleActive || huddleConversationId !== conversationId) return;
-    await huddlePeerConnection.setRemoteDescription(new RTCSessionDescription(answer));
+    try {
+      await huddlePeerConnection.setRemoteDescription(new RTCSessionDescription(answer));
+    } catch (error) {
+      console.error("Failed to set remote description:", error);
+      endHuddle();
+    }
   }
 
   async function handleHuddleIceCandidate(conversationId: number, candidate: RTCIceCandidateInit): Promise<void> {
@@ -779,6 +785,7 @@
     for (const track of huddleLocalStream.getAudioTracks()) {
       track.enabled = !huddleMuted;
     }
+    huddleMuteButton.setAttribute("aria-pressed", String(huddleMuted));
     if (huddleMuted) {
       huddleMuteButton.classList.add("muted");
     } else {

--- a/hono/static/ChatPage.ts
+++ b/hono/static/ChatPage.ts
@@ -50,6 +50,16 @@
   const dmComposeModal = document.getElementById("dmComposeModal") as HTMLDivElement;
   const dmSearchInput = document.getElementById("dmSearchInput") as HTMLInputElement;
   const dmMemberListEl = document.getElementById("dmMemberList") as HTMLUListElement;
+  const startHuddleButton = document.getElementById("startHuddleButton") as HTMLButtonElement;
+  const huddleIncomingBanner = document.getElementById("huddleIncomingBanner") as HTMLDivElement;
+  const huddleCallerName = document.getElementById("huddleCallerName") as HTMLSpanElement;
+  const huddleAcceptButton = document.getElementById("huddleAcceptButton") as HTMLButtonElement;
+  const huddleDeclineButton = document.getElementById("huddleDeclineButton") as HTMLButtonElement;
+  const huddleBar = document.getElementById("huddleBar") as HTMLDivElement;
+  const huddleStatus = document.getElementById("huddleStatus") as HTMLSpanElement;
+  const huddleMuteButton = document.getElementById("huddleMuteButton") as HTMLButtonElement;
+  const huddleEndButton = document.getElementById("huddleEndButton") as HTMLButtonElement;
+  const remoteAudio = document.getElementById("remoteAudio") as HTMLAudioElement;
 
   const STATUS_CLASS = "status";
   const CONNECTED_CLASS = "connected";
@@ -103,6 +113,20 @@
   let activeDmConversationId: number | null = null;
   let dmConversations: DmConversation[] = [];
   let allWorkspaceMembers: Member[] = [];
+
+  let huddleActive = false;
+  let huddlePeerConnection: RTCPeerConnection | null = null;
+  let huddleLocalStream: MediaStream | null = null;
+  let huddleConversationId: number | null = null;
+  let huddleOtherUserName = "";
+  let huddleMuted = false;
+  let pendingHuddleOffer: RTCSessionDescriptionInit | null = null;
+  let pendingHuddleCallerName = "";
+  let pendingHuddleConversationId: number | null = null;
+
+  const STUN_CONFIG: RTCConfiguration = {
+    iceServers: [{ urls: "stun:stun.cloudflare.com:3478" }],
+  };
 
   const MOBILE_BREAKPOINT = 768;
   const TABLET_BREAKPOINT = 1024;
@@ -426,6 +450,7 @@
     channelNameHeader.textContent = otherUserName;
     membersPanel.classList.add("hidden");
     toggleMembersButton.classList.add("hidden");
+    updateHuddleButtonVisibility();
     renderChannelLists();
     renderDmList();
     if (isMobileView()) closeSidebar();
@@ -437,6 +462,7 @@
     viewMode = "channel";
     activeDmConversationId = null;
     toggleMembersButton.classList.remove("hidden");
+    updateHuddleButtonVisibility();
     if (membersPanelVisible) {
       membersPanel.classList.remove("hidden");
     }
@@ -518,6 +544,253 @@
     } catch (error) {
       console.error("Error starting DM:", error);
     }
+  }
+
+  function updateHuddleButtonVisibility(): void {
+    if (viewMode === "dm" && !huddleActive) {
+      startHuddleButton.classList.remove("hidden");
+    } else {
+      startHuddleButton.classList.add("hidden");
+    }
+  }
+
+  function createPeerConnection(): RTCPeerConnection {
+    const pc = new RTCPeerConnection(STUN_CONFIG);
+
+    pc.onicecandidate = (event) => {
+      if (event.candidate && ws.readyState === WebSocket.OPEN && huddleConversationId !== null) {
+        ws.send(
+          JSON.stringify({
+            type: "huddle-ice-candidate",
+            conversationId: huddleConversationId,
+            candidate: event.candidate.toJSON(),
+          }),
+        );
+      }
+    };
+
+    pc.ontrack = (event) => {
+      if (event.streams[0]) {
+        remoteAudio.srcObject = event.streams[0];
+      }
+    };
+
+    pc.oniceconnectionstatechange = () => {
+      if (pc.iceConnectionState === "connected") {
+        huddleStatus.textContent = `Huddle with ${huddleOtherUserName}`;
+      } else if (pc.iceConnectionState === "disconnected" || pc.iceConnectionState === "failed") {
+        if (huddleConversationId !== null && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "huddle-end", conversationId: huddleConversationId }));
+        }
+        cleanupHuddle();
+      }
+    };
+
+    return pc;
+  }
+
+  function showHuddleBar(): void {
+    huddleBar.classList.remove("hidden");
+    startHuddleButton.classList.add("hidden");
+  }
+
+  function hideHuddleBar(): void {
+    huddleBar.classList.add("hidden");
+    huddleStatus.textContent = "Huddle";
+    updateHuddleButtonVisibility();
+  }
+
+  function showIncomingBanner(callerName: string): void {
+    huddleCallerName.textContent = callerName;
+    huddleIncomingBanner.classList.remove("hidden");
+  }
+
+  function hideIncomingBanner(): void {
+    huddleIncomingBanner.classList.add("hidden");
+    huddleCallerName.textContent = "";
+  }
+
+  function cleanupHuddle(): void {
+    if (huddleLocalStream) {
+      for (const track of huddleLocalStream.getTracks()) {
+        track.stop();
+      }
+      huddleLocalStream = null;
+    }
+
+    if (huddlePeerConnection) {
+      huddlePeerConnection.close();
+      huddlePeerConnection = null;
+    }
+
+    remoteAudio.srcObject = null;
+    huddleActive = false;
+    huddleConversationId = null;
+    huddleOtherUserName = "";
+    huddleMuted = false;
+    huddleMuteButton.classList.remove("muted");
+
+    hideHuddleBar();
+    hideIncomingBanner();
+  }
+
+  async function startHuddle(): Promise<void> {
+    if (huddleActive || viewMode !== "dm" || activeDmConversationId === null) return;
+    if (ws.readyState !== WebSocket.OPEN) return;
+
+    const activeConv = dmConversations.find((c) => c.id === activeDmConversationId);
+    if (!activeConv) return;
+
+    try {
+      huddleLocalStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+      console.error("Failed to get audio:", error);
+      return;
+    }
+
+    huddleActive = true;
+    huddleConversationId = activeDmConversationId;
+    huddleOtherUserName = activeConv.otherUserName;
+    huddleStatus.textContent = `Calling ${huddleOtherUserName}...`;
+    showHuddleBar();
+
+    try {
+      huddlePeerConnection = createPeerConnection();
+
+      for (const track of huddleLocalStream.getTracks()) {
+        huddlePeerConnection.addTrack(track, huddleLocalStream);
+      }
+
+      const offer = await huddlePeerConnection.createOffer();
+      await huddlePeerConnection.setLocalDescription(offer);
+
+      ws.send(
+        JSON.stringify({
+          type: "huddle-offer",
+          conversationId: huddleConversationId,
+          offer,
+        }),
+      );
+    } catch (error) {
+      console.error("Failed to start huddle:", error);
+      cleanupHuddle();
+    }
+  }
+
+  function handleHuddleOffer(conversationId: number, offer: RTCSessionDescriptionInit, callerName: string): void {
+    if (huddleActive) {
+      ws.send(JSON.stringify({ type: "huddle-end", conversationId }));
+      return;
+    }
+
+    pendingHuddleOffer = offer;
+    pendingHuddleCallerName = callerName;
+    pendingHuddleConversationId = conversationId;
+    showIncomingBanner(callerName);
+  }
+
+  async function acceptHuddle(): Promise<void> {
+    if (!pendingHuddleOffer || pendingHuddleConversationId === null) return;
+
+    hideIncomingBanner();
+
+    try {
+      huddleLocalStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+      console.error("Failed to get audio:", error);
+      pendingHuddleOffer = null;
+      pendingHuddleConversationId = null;
+      return;
+    }
+
+    huddleActive = true;
+    huddleConversationId = pendingHuddleConversationId;
+    huddleOtherUserName = pendingHuddleCallerName;
+    huddleStatus.textContent = `Huddle with ${huddleOtherUserName}`;
+    showHuddleBar();
+
+    try {
+      huddlePeerConnection = createPeerConnection();
+
+      for (const track of huddleLocalStream.getTracks()) {
+        huddlePeerConnection.addTrack(track, huddleLocalStream);
+      }
+
+      await huddlePeerConnection.setRemoteDescription(new RTCSessionDescription(pendingHuddleOffer));
+
+      const answer = await huddlePeerConnection.createAnswer();
+      await huddlePeerConnection.setLocalDescription(answer);
+
+      ws.send(
+        JSON.stringify({
+          type: "huddle-answer",
+          conversationId: huddleConversationId,
+          answer,
+        }),
+      );
+    } catch (error) {
+      console.error("Failed to accept huddle:", error);
+      cleanupHuddle();
+    }
+
+    pendingHuddleOffer = null;
+    pendingHuddleConversationId = null;
+  }
+
+  function declineHuddle(): void {
+    if (pendingHuddleConversationId !== null && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "huddle-end", conversationId: pendingHuddleConversationId }));
+    }
+    pendingHuddleOffer = null;
+    pendingHuddleCallerName = "";
+    pendingHuddleConversationId = null;
+    hideIncomingBanner();
+  }
+
+  async function handleHuddleAnswer(conversationId: number, answer: RTCSessionDescriptionInit): Promise<void> {
+    if (!huddlePeerConnection || !huddleActive || huddleConversationId !== conversationId) return;
+    await huddlePeerConnection.setRemoteDescription(new RTCSessionDescription(answer));
+  }
+
+  async function handleHuddleIceCandidate(conversationId: number, candidate: RTCIceCandidateInit): Promise<void> {
+    if (!huddlePeerConnection || huddleConversationId !== conversationId) return;
+    try {
+      await huddlePeerConnection.addIceCandidate(new RTCIceCandidate(candidate));
+    } catch (error) {
+      console.error("Error adding ICE candidate:", error);
+    }
+  }
+
+  function handleHuddleEnd(conversationId: number): void {
+    if (huddleActive && huddleConversationId === conversationId) {
+      cleanupHuddle();
+      return;
+    }
+    if (pendingHuddleConversationId === conversationId) {
+      pendingHuddleOffer = null;
+      pendingHuddleConversationId = null;
+      hideIncomingBanner();
+    }
+  }
+
+  function toggleMute(): void {
+    if (!huddleLocalStream) return;
+    huddleMuted = !huddleMuted;
+    for (const track of huddleLocalStream.getAudioTracks()) {
+      track.enabled = !huddleMuted;
+    }
+    if (huddleMuted) {
+      huddleMuteButton.classList.add("muted");
+    } else {
+      huddleMuteButton.classList.remove("muted");
+    }
+  }
+
+  function endHuddle(): void {
+    if (huddleConversationId !== null && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "huddle-end", conversationId: huddleConversationId }));
+    }
+    cleanupHuddle();
   }
 
   async function initChannels(): Promise<void> {
@@ -682,6 +955,12 @@
     }
   });
 
+  startHuddleButton.addEventListener("click", () => startHuddle());
+  huddleAcceptButton.addEventListener("click", () => acceptHuddle());
+  huddleDeclineButton.addEventListener("click", () => declineHuddle());
+  huddleMuteButton.addEventListener("click", () => toggleMute());
+  huddleEndButton.addEventListener("click", () => endHuddle());
+
   document.addEventListener("keydown", (e: KeyboardEvent) => {
     if (e.key === "Escape") {
       if (sidebar.classList.contains("open")) {
@@ -758,6 +1037,9 @@
           attachmentName?: string | null;
           attachmentType?: string | null;
           attachmentSize?: number | null;
+          offer?: RTCSessionDescriptionInit;
+          answer?: RTCSessionDescriptionInit;
+          candidate?: RTCIceCandidateInit;
         };
         if (data.type === "message" && viewMode === "channel" && data.channelId === activeChannelId) {
           displayMessage(data);
@@ -774,6 +1056,18 @@
         if ((data.type === "memberJoin" || data.type === "memberLeave") && data.channelId === activeChannelId) {
           fetchChannelMembers(data.channelId);
         }
+        if (data.type === "huddle-offer" && data.conversationId && data.offer) {
+          handleHuddleOffer(data.conversationId, data.offer, data.userName || data.userEmail);
+        }
+        if (data.type === "huddle-answer" && data.conversationId && data.answer) {
+          handleHuddleAnswer(data.conversationId, data.answer);
+        }
+        if (data.type === "huddle-ice-candidate" && data.conversationId && data.candidate) {
+          handleHuddleIceCandidate(data.conversationId, data.candidate);
+        }
+        if (data.type === "huddle-end" && data.conversationId) {
+          handleHuddleEnd(data.conversationId);
+        }
       } catch {
         // Ignore non-JSON messages
       }
@@ -785,6 +1079,10 @@
       messageInput.disabled = true;
       sendButton.disabled = true;
       attachButton.disabled = true;
+
+      if (huddleActive) {
+        cleanupHuddle();
+      }
 
       if (event.code === UNAUTHORIZED_CLOSE_CODE) {
         statusDiv.textContent = "Disconnected (unauthorized)";


### PR DESCRIPTION
## Summary

- Add WebRTC peer-to-peer audio huddles in direct message conversations, reusing the existing ChatRoom Durable Object WebSocket for signaling (no new infrastructure)
- Server-side: relay `huddle-offer`, `huddle-answer`, `huddle-ice-candidate`, and `huddle-end` signals to the other DM participant with authorization checks
- Client-side: "Start Huddle" button in DM header, incoming call banner (accept/decline), active huddle bar (mute toggle, end call), STUN-only `RTCPeerConnection` via `stun:stun.cloudflare.com:3478`

## Architecture

```
User A clicks "Start Huddle" → getUserMedia(audio) → RTCPeerConnection
  → SDP offer sent via existing WebSocket as { type: "huddle-offer" }
  → ChatRoom DO verifies DM authorization, relays to User B only
  → User B sees incoming call banner, clicks Accept
  → getUserMedia(audio) → SDP answer sent back
  → ICE candidates exchanged → P2P audio established
  → Either side clicks End → { type: "huddle-end" }
```

## Design decisions

- **No new Durable Object** — reuses existing ChatRoom DO and WebSocket
- **No call state persistence** — signals are ephemeral, no DB writes
- **STUN-only** — no TURN server needed for first iteration
- **Audio-only** — video can be added as a future enhancement
- **Signals go to other participant only** (unlike DMs which go to both)

## Files changed

| File | Change |
|------|--------|
| `hono/durableObjects/ChatRoom.ts` | `handleHuddleSignal()` — DM auth, relay to other participant, payload validation |
| `hono/components/ChatPage.tsx` | Huddle button, incoming call banner, active huddle bar, `<audio>` element |
| `hono/components/ChatPage.css` | Huddle bar, incoming banner, control button styles with animations |
| `hono/static/ChatPage.ts` | WebRTC state machine, signaling handlers, mute/end controls |
| `hono/components/ChatPage.test.ts` | 6 new tests for huddle UI elements (173 total) |

## Testing

- `pnpm test:run` — 173 tests pass (6 new)
- `pnpm lint` — clean
- `pnpm build` — clean
- Copilot CLI reviews run on all modified files; post-review fixes applied (conversationId validation, try/catch on WebRTC calls, huddle-end on ICE disconnect)