### PR TITLE
fix(auth): harden security across auth and WebSocket layers

### DIFF
--- a/hono/app.test.ts
+++ b/hono/app.test.ts
@@ -8,4 +8,19 @@ describe("App integration", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("should return 500 when SESSION_SECRET is not set", { timeout: 15000 }, async () => {
+    const { createApp } = await import("./app.js");
+    const { app } = createApp();
+
+    const request = new Request("http://localhost/health", {
+      headers: { Origin: "http://localhost" },
+    });
+
+    const response = await app.fetch(request, {
+      DB: {} as D1Database,
+      CHAT_ROOM: {} as DurableObjectNamespace,
+    } as never);
+    expect(response.status).toBe(500);
+  });
 });

--- a/hono/app.tsx
+++ b/hono/app.tsx
@@ -27,9 +27,12 @@ function createLazySessionMiddleware(): MiddlewareHandler<Env> {
   return async (c, next) => {
     if (!cached) {
       const store = new CookieStore();
+      if (!c.env.SESSION_SECRET) {
+        throw new Error("SESSION_SECRET environment variable is required");
+      }
       cached = sessionMiddleware({
         store,
-        encryptionKey: c.env.SESSION_SECRET || "your-super-secret-key-change-in-production",
+        encryptionKey: c.env.SESSION_SECRET,
         expireAfterSeconds: 3600,
         cookieOptions: {
           httpOnly: true,

--- a/hono/auth/rateLimiter.test.ts
+++ b/hono/auth/rateLimiter.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types.js";
 import { _resetStores, createRateLimiter } from "./rateLimiter.js";
 
@@ -19,6 +19,7 @@ function makeRequest(app: Hono<Env>, ip = "1.2.3.4") {
 
 afterEach(() => {
   _resetStores();
+  vi.useRealTimers();
 });
 
 describe("createRateLimiter", () => {
@@ -72,8 +73,6 @@ describe("createRateLimiter", () => {
 
     const res2 = await makeRequest(app);
     expect(res2.status).toBe(200);
-
-    vi.useRealTimers();
   });
 
   it("should fall back to x-forwarded-for when cf-connecting-ip is absent", async () => {
@@ -119,5 +118,49 @@ describe("createRateLimiter", () => {
     expect(() => createRateLimiter("bad-max", { windowMs: 1000, maxRequests: -1 })).toThrow(
       "windowMs and maxRequests must be positive",
     );
+  });
+
+  it("should use custom onLimitExceeded handler when provided", async () => {
+    const app = new Hono<Env>();
+    app.use(
+      "/test",
+      createRateLimiter("test-custom-handler", {
+        windowMs: 60_000,
+        maxRequests: 1,
+        onLimitExceeded: (c) => c.html("<h1>Rate limited</h1>", 429),
+      }),
+    );
+    app.post("/test", (c) => c.json({ ok: true }));
+
+    const res1 = await app.request("/test", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "1.2.3.4" },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/test", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "1.2.3.4" },
+    });
+    expect(res2.status).toBe(429);
+    const body = await res2.text();
+    expect(body).toContain("Rate limited");
+  });
+
+  it("should clean up stale entries after the window passes", async () => {
+    vi.useFakeTimers();
+    const app = createTestApp("test-cleanup", 1, 1000);
+
+    await makeRequest(app, "10.0.0.1");
+    await makeRequest(app, "10.0.0.2");
+    await makeRequest(app, "10.0.0.3");
+
+    const blockedRes = await makeRequest(app, "10.0.0.1");
+    expect(blockedRes.status).toBe(429);
+
+    await vi.advanceTimersByTimeAsync(1001);
+
+    const afterWindowRes = await makeRequest(app, "10.0.0.1");
+    expect(afterWindowRes.status).toBe(200);
   });
 });

--- a/hono/auth/rateLimiter.test.ts
+++ b/hono/auth/rateLimiter.test.ts
@@ -1,0 +1,123 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Env } from "../types.js";
+import { _resetStores, createRateLimiter } from "./rateLimiter.js";
+
+function createTestApp(storeKey: string, maxRequests: number, windowMs: number) {
+  const app = new Hono<Env>();
+  app.use("/test", createRateLimiter(storeKey, { windowMs, maxRequests }));
+  app.post("/test", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function makeRequest(app: Hono<Env>, ip = "1.2.3.4") {
+  return app.request("/test", {
+    method: "POST",
+    headers: { "cf-connecting-ip": ip },
+  });
+}
+
+afterEach(() => {
+  _resetStores();
+});
+
+describe("createRateLimiter", () => {
+  it("should allow requests under the limit", async () => {
+    const app = createTestApp("test-under", 3, 60_000);
+
+    const res1 = await makeRequest(app);
+    const res2 = await makeRequest(app);
+    const res3 = await makeRequest(app);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(res3.status).toBe(200);
+  });
+
+  it("should return 429 when limit is exceeded", async () => {
+    const app = createTestApp("test-exceeded", 2, 60_000);
+
+    await makeRequest(app);
+    await makeRequest(app);
+    const res = await makeRequest(app);
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("Too many requests");
+  });
+
+  it("should track IPs independently", async () => {
+    const app = createTestApp("test-ips", 1, 60_000);
+
+    const res1 = await makeRequest(app, "10.0.0.1");
+    const res2 = await makeRequest(app, "10.0.0.2");
+    const blocked = await makeRequest(app, "10.0.0.1");
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(blocked.status).toBe(429);
+  });
+
+  it("should allow requests after the window expires", async () => {
+    vi.useFakeTimers();
+    const app = createTestApp("test-expire", 1, 1000);
+
+    const res1 = await makeRequest(app);
+    expect(res1.status).toBe(200);
+
+    const blocked = await makeRequest(app);
+    expect(blocked.status).toBe(429);
+
+    await vi.advanceTimersByTimeAsync(1001);
+
+    const res2 = await makeRequest(app);
+    expect(res2.status).toBe(200);
+
+    vi.useRealTimers();
+  });
+
+  it("should fall back to x-forwarded-for when cf-connecting-ip is absent", async () => {
+    const app = createTestApp("test-xff", 1, 60_000);
+
+    const res1 = await app.request("/test", {
+      method: "POST",
+      headers: { "x-forwarded-for": "5.6.7.8, 10.0.0.1" },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/test", {
+      method: "POST",
+      headers: { "x-forwarded-for": "5.6.7.8, 10.0.0.1" },
+    });
+    expect(res2.status).toBe(429);
+  });
+
+  it("should use separate stores for different store keys", async () => {
+    const app = new Hono<Env>();
+    app.use("/login", createRateLimiter("login", { windowMs: 60_000, maxRequests: 1 }));
+    app.post("/login", (c) => c.json({ ok: true }));
+    app.use("/register", createRateLimiter("register", { windowMs: 60_000, maxRequests: 1 }));
+    app.post("/register", (c) => c.json({ ok: true }));
+
+    const loginRes = await app.request("/login", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "1.1.1.1" },
+    });
+    expect(loginRes.status).toBe(200);
+
+    const registerRes = await app.request("/register", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "1.1.1.1" },
+    });
+    expect(registerRes.status).toBe(200);
+  });
+
+  it("should throw on invalid options", () => {
+    expect(() => createRateLimiter("bad-window", { windowMs: 0, maxRequests: 5 })).toThrow(
+      "windowMs and maxRequests must be positive",
+    );
+    expect(() => createRateLimiter("bad-max", { windowMs: 1000, maxRequests: -1 })).toThrow(
+      "windowMs and maxRequests must be positive",
+    );
+  });
+});

--- a/hono/auth/rateLimiter.ts
+++ b/hono/auth/rateLimiter.ts
@@ -4,6 +4,7 @@ import type { Env } from "../types.js";
 type RateLimitOptions = {
   windowMs: number;
   maxRequests: number;
+  onLimitExceeded?: (c: Context<Env>) => Response | Promise<Response>;
 };
 
 type RequestRecord = {
@@ -30,12 +31,23 @@ export function createRateLimiter(storeKey: string, options: RateLimitOptions): 
     throw new Error("windowMs and maxRequests must be positive");
   }
 
-  const { windowMs, maxRequests } = options;
+  const { windowMs, maxRequests, onLimitExceeded } = options;
   const store = getStore(storeKey);
+  let lastCleanup = Date.now();
 
   return async (c, next) => {
     const ip = getClientIp(c);
     const now = Date.now();
+
+    if (now - lastCleanup > windowMs) {
+      for (const [key, rec] of store) {
+        rec.timestamps = rec.timestamps.filter((ts) => now - ts < windowMs);
+        if (rec.timestamps.length === 0) {
+          store.delete(key);
+        }
+      }
+      lastCleanup = now;
+    }
 
     const record = store.get(ip);
     if (!record) {
@@ -46,7 +58,16 @@ export function createRateLimiter(storeKey: string, options: RateLimitOptions): 
 
     record.timestamps = record.timestamps.filter((ts) => now - ts < windowMs);
 
+    if (record.timestamps.length === 0) {
+      record.timestamps.push(now);
+      await next();
+      return;
+    }
+
     if (record.timestamps.length >= maxRequests) {
+      if (onLimitExceeded) {
+        return onLimitExceeded(c);
+      }
       return c.json({ error: "Too many requests. Please try again later." }, 429);
     }
 

--- a/hono/auth/rateLimiter.ts
+++ b/hono/auth/rateLimiter.ts
@@ -1,0 +1,60 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { Env } from "../types.js";
+
+type RateLimitOptions = {
+  windowMs: number;
+  maxRequests: number;
+};
+
+type RequestRecord = {
+  timestamps: number[];
+};
+
+const stores = new Map<string, Map<string, RequestRecord>>();
+
+function getStore(storeKey: string): Map<string, RequestRecord> {
+  let store = stores.get(storeKey);
+  if (!store) {
+    store = new Map();
+    stores.set(storeKey, store);
+  }
+  return store;
+}
+
+function getClientIp(c: Context<Env>): string {
+  return c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+}
+
+export function createRateLimiter(storeKey: string, options: RateLimitOptions): MiddlewareHandler<Env> {
+  if (options.windowMs <= 0 || options.maxRequests <= 0) {
+    throw new Error("windowMs and maxRequests must be positive");
+  }
+
+  const { windowMs, maxRequests } = options;
+  const store = getStore(storeKey);
+
+  return async (c, next) => {
+    const ip = getClientIp(c);
+    const now = Date.now();
+
+    const record = store.get(ip);
+    if (!record) {
+      store.set(ip, { timestamps: [now] });
+      await next();
+      return;
+    }
+
+    record.timestamps = record.timestamps.filter((ts) => now - ts < windowMs);
+
+    if (record.timestamps.length >= maxRequests) {
+      return c.json({ error: "Too many requests. Please try again later." }, 429);
+    }
+
+    record.timestamps.push(now);
+    await next();
+  };
+}
+
+export function _resetStores(): void {
+  stores.clear();
+}

--- a/hono/durableObjects/ChatRoom.ts
+++ b/hono/durableObjects/ChatRoom.ts
@@ -45,6 +45,9 @@ type IncomingHuddleSignal = {
 
 const HUDDLE_TYPES = new Set(["huddle-offer", "huddle-answer", "huddle-ice-candidate", "huddle-end"]);
 
+const MAX_MESSAGE_LENGTH = 4096;
+const MAX_WEBSOCKET_PAYLOAD_BYTES = 65536;
+
 export class ChatRoom extends DurableObject<Bindings> {
   private dmAuthCache = new Map<string, string>();
 
@@ -76,6 +79,17 @@ export class ChatRoom extends DurableObject<Bindings> {
   async webSocketMessage(ws: WebSocket, message: ArrayBuffer | string): Promise<void> {
     const attachment = ws.deserializeAttachment() as SessionAttachment | null;
     if (!attachment) {
+      return;
+    }
+
+    const payloadBytes =
+      typeof message === "string" ? new TextEncoder().encode(message).byteLength : message.byteLength;
+    if (payloadBytes > MAX_WEBSOCKET_PAYLOAD_BYTES) {
+      try {
+        ws.send(JSON.stringify({ type: "error", error: "Message payload too large" }));
+      } catch {
+        // Socket may be closed
+      }
       return;
     }
 
@@ -111,6 +125,15 @@ export class ChatRoom extends DurableObject<Bindings> {
     const hasContent = Boolean(msg.content?.trim());
     const hasAttachment = Boolean(msg.attachmentKey);
     if (!hasContent && !hasAttachment) {
+      return;
+    }
+
+    if (msg.content && msg.content.length > MAX_MESSAGE_LENGTH) {
+      try {
+        ws.send(JSON.stringify({ type: "error", error: "Message too long" }));
+      } catch {
+        // Socket may be closed
+      }
       return;
     }
 
@@ -188,6 +211,15 @@ export class ChatRoom extends DurableObject<Bindings> {
     const hasContent = Boolean(dm.content?.trim());
     const hasAttachment = Boolean(dm.attachmentKey);
     if (!hasContent && !hasAttachment) {
+      return;
+    }
+
+    if (dm.content && dm.content.length > MAX_MESSAGE_LENGTH) {
+      try {
+        ws.send(JSON.stringify({ type: "error", error: "Message too long" }));
+      } catch {
+        // Socket may be closed
+      }
       return;
     }
 

--- a/hono/durableObjects/ChatRoom.ts
+++ b/hono/durableObjects/ChatRoom.ts
@@ -47,6 +47,8 @@ const HUDDLE_TYPES = new Set(["huddle-offer", "huddle-answer", "huddle-ice-candi
 
 const MAX_MESSAGE_LENGTH = 4096;
 const MAX_WEBSOCKET_PAYLOAD_BYTES = 65536;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 export class ChatRoom extends DurableObject<Bindings> {
   private dmAuthCache = new Map<string, string>();
@@ -82,8 +84,7 @@ export class ChatRoom extends DurableObject<Bindings> {
       return;
     }
 
-    const payloadBytes =
-      typeof message === "string" ? new TextEncoder().encode(message).byteLength : message.byteLength;
+    const payloadBytes = typeof message === "string" ? textEncoder.encode(message).byteLength : message.byteLength;
     if (payloadBytes > MAX_WEBSOCKET_PAYLOAD_BYTES) {
       try {
         ws.send(JSON.stringify({ type: "error", error: "Message payload too large" }));
@@ -93,7 +94,7 @@ export class ChatRoom extends DurableObject<Bindings> {
       return;
     }
 
-    const rawStr = typeof message === "string" ? message : new TextDecoder().decode(message);
+    const rawStr = typeof message === "string" ? message : textDecoder.decode(message);
 
     let parsed: IncomingMessage | IncomingDm | MembershipEvent | IncomingHuddleSignal;
     try {

--- a/hono/routes/emailAuth.test.ts
+++ b/hono/routes/emailAuth.test.ts
@@ -67,6 +67,13 @@ vi.mock("../auth/emailVerification.js", () => ({
   sendVerificationEmail: mockSendVerificationEmail,
 }));
 
+vi.mock("../auth/rateLimiter.js", () => ({
+  createRateLimiter: () => {
+    const passthrough: import("hono").MiddlewareHandler = async (_c, next) => next();
+    return passthrough;
+  },
+}));
+
 describe("Email Auth routes", () => {
   describe("GET /auth/login", () => {
     it("should return the login page", async () => {

--- a/hono/routes/emailAuth.ts
+++ b/hono/routes/emailAuth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { eq, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import {
@@ -7,12 +8,20 @@ import {
   sendVerificationEmail,
 } from "../auth/emailVerification.js";
 import { hashPassword, verifyPassword } from "../auth/password.js";
+import { createRateLimiter } from "../auth/rateLimiter.js";
 import { LoginPage } from "../components/LoginPage.js";
 import { RegisterPage } from "../components/RegisterPage.js";
 import { VerifyEmailPage } from "../components/VerifyEmailPage.js";
 import { getDb, pendingRegistrations, users } from "../db/index.js";
 import { renderPage } from "../helpers/renderPage.js";
 import type { Bindings, Env } from "../types.js";
+
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+const loginRateLimiter = createRateLimiter("auth-login", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 10 });
+const registerRateLimiter = createRateLimiter("auth-register", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 5 });
+const verifyRateLimiter = createRateLimiter("auth-verify", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 10 });
+const resendRateLimiter = createRateLimiter("auth-resend", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 5 });
 
 const emailAuthRoute = new Hono<Env>();
 
@@ -39,10 +48,10 @@ emailAuthRoute.get("/auth/login", async (c) => {
   return renderPage(c, LoginPage(errorMessage));
 });
 
-emailAuthRoute.post("/auth/login", async (c) => {
+emailAuthRoute.post("/auth/login", loginRateLimiter, async (c) => {
   try {
     const body = await c.req.parseBody();
-    const email = body.email as string;
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
     const password = body.password as string;
 
     if (!email || !password) {
@@ -85,11 +94,11 @@ emailAuthRoute.get("/auth/register", async (c) => {
   return renderPage(c, RegisterPage(errorMessage));
 });
 
-emailAuthRoute.post("/auth/register", async (c) => {
+emailAuthRoute.post("/auth/register", registerRateLimiter, async (c) => {
   try {
     const body = await c.req.parseBody();
-    const name = body.name as string;
-    const email = body.email as string;
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
     const password = body.password as string;
 
     if (!name || !email || !password) {
@@ -140,11 +149,11 @@ emailAuthRoute.get("/auth/verify-email", async (c) => {
   return renderPage(c, VerifyEmailPage({ email }));
 });
 
-emailAuthRoute.post("/auth/verify-email", async (c) => {
+emailAuthRoute.post("/auth/verify-email", verifyRateLimiter, async (c) => {
   try {
     const body = await c.req.parseBody();
-    const email = body.email as string;
-    const code = body.code as string;
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const code = typeof body.code === "string" ? body.code.trim() : "";
 
     if (!email || !code) {
       return renderPage(c, VerifyEmailPage({ email: email || "", error: "Email and code are required." }), 400);
@@ -174,7 +183,11 @@ emailAuthRoute.post("/auth/verify-email", async (c) => {
       );
     }
 
-    if (pending.verificationCode !== code) {
+    const storedCodeBuffer = Buffer.from(pending.verificationCode);
+    const submittedCodeBuffer = Buffer.from(code);
+    const codeMatches =
+      storedCodeBuffer.length === submittedCodeBuffer.length && timingSafeEqual(storedCodeBuffer, submittedCodeBuffer);
+    if (!codeMatches) {
       return renderPage(c, VerifyEmailPage({ email, error: "Invalid verification code." }), 400);
     }
 
@@ -201,10 +214,10 @@ emailAuthRoute.post("/auth/verify-email", async (c) => {
   }
 });
 
-emailAuthRoute.post("/auth/resend-code", async (c) => {
+emailAuthRoute.post("/auth/resend-code", resendRateLimiter, async (c) => {
   try {
     const body = await c.req.parseBody();
-    const email = body.email as string;
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
 
     if (!email) {
       return c.redirect("/auth/register");

--- a/hono/routes/emailAuth.ts
+++ b/hono/routes/emailAuth.ts
@@ -17,11 +17,34 @@ import { renderPage } from "../helpers/renderPage.js";
 import type { Bindings, Env } from "../types.js";
 
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const RATE_LIMIT_MESSAGE = "Too many attempts. Please try again later.";
 
-const loginRateLimiter = createRateLimiter("auth-login", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 10 });
-const registerRateLimiter = createRateLimiter("auth-register", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 5 });
-const verifyRateLimiter = createRateLimiter("auth-verify", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 10 });
-const resendRateLimiter = createRateLimiter("auth-resend", { windowMs: RATE_LIMIT_WINDOW_MS, maxRequests: 5 });
+const loginRateLimiter = createRateLimiter("auth-login", {
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: 10,
+  onLimitExceeded: (c) => renderPage(c, LoginPage(RATE_LIMIT_MESSAGE), 429),
+});
+const registerRateLimiter = createRateLimiter("auth-register", {
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: 5,
+  onLimitExceeded: (c) => renderPage(c, RegisterPage(RATE_LIMIT_MESSAGE), 429),
+});
+const verifyRateLimiter = createRateLimiter("auth-verify", {
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: 10,
+  onLimitExceeded: (c) => {
+    const email = c.req.query("email") || "";
+    return renderPage(c, VerifyEmailPage({ email, error: RATE_LIMIT_MESSAGE }), 429);
+  },
+});
+const resendRateLimiter = createRateLimiter("auth-resend", {
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: 5,
+  onLimitExceeded: (c) => {
+    const email = c.req.query("email") || "";
+    return renderPage(c, VerifyEmailPage({ email, error: RATE_LIMIT_MESSAGE }), 429);
+  },
+});
 
 const emailAuthRoute = new Hono<Env>();
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `pnpm build:client && pnpm run build:assets && wrangler dev --port 3015 --var E2E_GMAIL_ACCOUNT:${process.env.E2E_GMAIL_ACCOUNT ?? "test@example.com"}`,
+    command: `pnpm build:client && pnpm run build:assets && wrangler dev --port 3015 --var E2E_GMAIL_ACCOUNT:${process.env.E2E_GMAIL_ACCOUNT ?? "test@example.com"} --var SESSION_SECRET:${process.env.SESSION_SECRET || "e2e-test-session-secret-key"}`,
     url: "http://localhost:3015",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,


### PR DESCRIPTION
## Summary

Security hardening pass addressing four critical gaps identified during a codebase review.

## Changes

| Fix | File(s) |
|-----|---------|
| **Fail-fast on missing `SESSION_SECRET`** — removes hardcoded fallback; app errors immediately if env var is unset | `app.tsx`, `app.test.ts` |
| **Timing-safe verification code comparison** — replaces `!==` with `timingSafeEqual` to prevent timing attacks (password verification already did this correctly) | `emailAuth.ts` |
| **Rate limiting on auth endpoints** — new IP-based sliding-window middleware; 10 req/15min for login/verify, 5 req/15min for register/resend | `rateLimiter.ts` (new), `rateLimiter.test.ts` (new), `emailAuth.ts` |
| **WebSocket message size limits** — 4096-char content cap + 64KB payload cap using proper byte-length check | `ChatRoom.ts` |
| **Email input normalization** — `trim().toLowerCase()` on all auth form inputs to prevent case-sensitive duplicates | `emailAuth.ts` |

## Testing

- 181 unit tests pass (including 7 new tests for rate limiter + 1 for session secret)
- Lint clean, build succeeds
- Rate limiter tests use fake timers for deterministic window expiry

## Notes

- Rate limiting is in-memory (per-isolate), which is a pragmatic first step. For distributed enforcement, a follow-up could use Durable Objects or KV.
- Existing `emailAuth.test.ts` tests mock the rate limiter to avoid interference with unit test isolation.