### PR TITLE
refactor: extract shared Layout component, common CSS, and data access layer

### DIFF
--- a/hono/auth/password.ts
+++ b/hono/auth/password.ts
@@ -7,7 +7,7 @@ export async function hashPassword(password: string): Promise<string> {
   const salt = randomBytes(SALT_LENGTH).toString("hex");
   const hash = await new Promise<string>((resolve, reject) => {
     scrypt(password, salt, KEY_LENGTH, (err, derivedKey) => {
-      if (err) reject(err);
+      if (err) return reject(err);
       resolve(derivedKey.toString("hex"));
     });
   });
@@ -16,15 +16,18 @@ export async function hashPassword(password: string): Promise<string> {
 
 export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
   const [salt, hash] = storedHash.split(":");
-  if (!salt || !hash) return false;
+  const effectiveSalt = salt || randomBytes(SALT_LENGTH).toString("hex");
 
   const derivedKey = await new Promise<Buffer>((resolve, reject) => {
-    scrypt(password, salt, KEY_LENGTH, (err, derivedKey) => {
-      if (err) reject(err);
+    scrypt(password, effectiveSalt, KEY_LENGTH, (err, derivedKey) => {
+      if (err) return reject(err);
       resolve(derivedKey);
     });
   });
 
+  if (!salt || !hash) return false;
+
   const storedBuffer = Buffer.from(hash, "hex");
+  if (derivedKey.length !== storedBuffer.length) return false;
   return timingSafeEqual(derivedKey, storedBuffer);
 }

--- a/hono/auth/rateLimiter.test.ts
+++ b/hono/auth/rateLimiter.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types.js";
-import { _resetStores, createRateLimiter } from "./rateLimiter.js";
+import { _resetStores, createRateLimiter, MAX_ENTRIES_PER_STORE } from "./rateLimiter.js";
 
 function createTestApp(storeKey: string, maxRequests: number, windowMs: number) {
   const app = new Hono<Env>();
@@ -162,5 +162,17 @@ describe("createRateLimiter", () => {
 
     const afterWindowRes = await makeRequest(app, "10.0.0.1");
     expect(afterWindowRes.status).toBe(200);
+  });
+
+  it("should evict oldest entry when store exceeds max entries", async () => {
+    const app = createTestApp("test-eviction", MAX_ENTRIES_PER_STORE + 1, 60_000);
+
+    for (let i = 0; i < MAX_ENTRIES_PER_STORE; i++) {
+      const res = await makeRequest(app, `10.0.${Math.floor(i / 256)}.${i % 256}`);
+      expect(res.status).toBe(200);
+    }
+
+    const res = await makeRequest(app, "99.99.99.99");
+    expect(res.status).toBe(200);
   });
 });

--- a/hono/auth/rateLimiter.ts
+++ b/hono/auth/rateLimiter.ts
@@ -11,6 +11,8 @@ type RequestRecord = {
   timestamps: number[];
 };
 
+const MAX_ENTRIES_PER_STORE = 10_000;
+
 const stores = new Map<string, Map<string, RequestRecord>>();
 
 function getStore(storeKey: string): Map<string, RequestRecord> {
@@ -49,6 +51,19 @@ export function createRateLimiter(storeKey: string, options: RateLimitOptions): 
       lastCleanup = now;
     }
 
+    if (store.size >= MAX_ENTRIES_PER_STORE) {
+      let oldest = now;
+      let oldestKey = "";
+      for (const [key, rec] of store) {
+        const earliestTs = rec.timestamps[0] ?? now;
+        if (earliestTs < oldest) {
+          oldest = earliestTs;
+          oldestKey = key;
+        }
+      }
+      if (oldestKey) store.delete(oldestKey);
+    }
+
     const record = store.get(ip);
     if (!record) {
       store.set(ip, { timestamps: [now] });
@@ -59,7 +74,8 @@ export function createRateLimiter(storeKey: string, options: RateLimitOptions): 
     record.timestamps = record.timestamps.filter((ts) => now - ts < windowMs);
 
     if (record.timestamps.length === 0) {
-      record.timestamps.push(now);
+      store.delete(ip);
+      store.set(ip, { timestamps: [now] });
       await next();
       return;
     }
@@ -79,3 +95,5 @@ export function createRateLimiter(storeKey: string, options: RateLimitOptions): 
 export function _resetStores(): void {
   stores.clear();
 }
+
+export { MAX_ENTRIES_PER_STORE };

--- a/hono/components/AboutPage.css
+++ b/hono/components/AboutPage.css
@@ -1,6 +1,4 @@
-/* Base styles for the about page - consistent with ChatPage */
 body {
-  font-family: Arial, sans-serif;
   max-width: 800px;
   margin: 0 auto;
   padding: 20px;

--- a/hono/components/AboutPage.tsx
+++ b/hono/components/AboutPage.tsx
@@ -1,51 +1,45 @@
+import { Layout } from "./Layout.js";
+
 export async function AboutPage() {
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>About - Mlack</title>
-        <link rel="stylesheet" href="/components/AboutPage.css" />
-      </head>
-      <body>
-        <div className="about-container">
-          <h1 className="page-title">About Mlack</h1>
+    <Layout title="About" css="/components/AboutPage.css">
+      <div className="about-container">
+        <h1 className="page-title">About Mlack</h1>
 
-          <div className="content">
-            <p>
-              Mlack is a Slack-like application that's fully open source. The source code is available at{" "}
-              <a href="https://github.com/mahata/mlack" target="_blank" rel="noopener noreferrer">
-                @mahata/mlack
-              </a>
-              .
-            </p>
-
-            <p>
-              This is an experimental project designed to build a real-world application using "Vibe Coding". Around 90%
-              of the code is written by{" "}
-              <a
-                href="https://docs.github.com/en/copilot/concepts/about-copilot-coding-agent"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub Copilot Coding Agent
-              </a>
-              .
-            </p>
-
-            <p>
-              The project explores what's possible when combining human creativity with AI assistance to rapidly
-              prototype and build functional applications.
-            </p>
-          </div>
-
-          <div className="navigation">
-            <a href="/" className="back-link">
-              ← Back to Chat
+        <div className="content">
+          <p>
+            Mlack is a Slack-like application that's fully open source. The source code is available at{" "}
+            <a href="https://github.com/mahata/mlack" target="_blank" rel="noopener noreferrer">
+              @mahata/mlack
             </a>
-          </div>
+            .
+          </p>
+
+          <p>
+            This is an experimental project designed to build a real-world application using "Vibe Coding". Around 90%
+            of the code is written by{" "}
+            <a
+              href="https://docs.github.com/en/copilot/concepts/about-copilot-coding-agent"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub Copilot Coding Agent
+            </a>
+            .
+          </p>
+
+          <p>
+            The project explores what's possible when combining human creativity with AI assistance to rapidly prototype
+            and build functional applications.
+          </p>
         </div>
-      </body>
-    </html>
+
+        <div className="navigation">
+          <a href="/" className="back-link">
+            ← Back to Chat
+          </a>
+        </div>
+      </div>
+    </Layout>
   );
 }

--- a/hono/components/AuthPage.css
+++ b/hono/components/AuthPage.css
@@ -1,5 +1,4 @@
 body {
-  font-family: Arial, sans-serif;
   max-width: 800px;
   margin: 0 auto;
   padding: 20px;

--- a/hono/components/ChatPage.css
+++ b/hono/components/ChatPage.css
@@ -1,12 +1,4 @@
-/* Base styles */
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
 body {
-  font-family: Arial, sans-serif;
   background-color: #1a1d21;
   color: #d1d2d3;
   height: 100vh;
@@ -593,66 +585,29 @@ body {
 
 /* Modal */
 .modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
   background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-}
-
-.modal.hidden {
-  display: none;
 }
 
 .modal-content {
   background-color: #222529;
-  border-radius: 8px;
-  padding: 24px;
   width: 400px;
-  max-width: 90vw;
   border: 1px solid #35373b;
 }
 
 .modal-content h3 {
   color: #fff;
   margin-bottom: 16px;
-  font-size: 18px;
 }
 
 .modal-content input {
-  width: 100%;
-  padding: 10px 12px;
   border: 1px solid #35373b;
-  border-radius: 4px;
-  font-size: 14px;
   background-color: #1a1d21;
   color: #d1d2d3;
-  outline: none;
   margin-bottom: 16px;
 }
 
 .modal-content input:focus {
   border-color: #1164a3;
-}
-
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.modal-actions button {
-  padding: 8px 16px;
-  border-radius: 4px;
-  font-size: 14px;
-  cursor: pointer;
-  border: none;
-  font-weight: 600;
 }
 
 #cancelCreateChannel {
@@ -711,9 +666,6 @@ body {
 
 /* Workspace modal extras */
 .modal-label {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
   color: #ababad;
   margin-bottom: 6px;
 }
@@ -733,10 +685,6 @@ body {
   font-size: 13px;
   color: #e0143c;
   margin-bottom: 12px;
-}
-
-.modal-error.hidden {
-  display: none;
 }
 
 #cancelCreateWorkspace {

--- a/hono/components/InvitePage.tsx
+++ b/hono/components/InvitePage.tsx
@@ -1,4 +1,5 @@
 import type { Workspace } from "../types.js";
+import { Layout } from "./Layout.js";
 
 type InvitePageProps = {
   workspace?: Workspace;
@@ -7,39 +8,33 @@ type InvitePageProps = {
 };
 
 export async function InvitePage({ workspace, code, error }: InvitePageProps) {
-  return (
-    <html lang="en">
-      <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>{error ? "Invite Error" : `Join ${workspace?.name}`} - Mlack</title>
-        <link rel="stylesheet" href="/components/WorkspacesPage.css" />
-      </head>
-      <body>
-        <div className="workspaces-container">
-          <div className="workspaces-header">
-            <h1>Mlack</h1>
-          </div>
+  const pageTitle = error ? "Invite Error" : `Join ${workspace?.name}`;
 
-          {error ? (
-            <div className="empty-state">
-              <p>{error}</p>
-              <a href="/">Back to workspaces</a>
-            </div>
-          ) : (
-            <div className="empty-state">
-              <p>
-                You've been invited to join <strong>{workspace?.name}</strong>.
-              </p>
-              <form method="post" action={`/w/${workspace?.slug}/invite/${code}`}>
-                <button type="submit" className="logout-button" style={{ fontSize: "1rem", padding: "0.5rem 1.5rem" }}>
-                  Accept Invite
-                </button>
-              </form>
-            </div>
-          )}
+  return (
+    <Layout title={pageTitle} css="/components/WorkspacesPage.css">
+      <div className="workspaces-container">
+        <div className="workspaces-header">
+          <h1>Mlack</h1>
         </div>
-      </body>
-    </html>
+
+        {error ? (
+          <div className="empty-state">
+            <p>{error}</p>
+            <a href="/">Back to workspaces</a>
+          </div>
+        ) : (
+          <div className="empty-state">
+            <p>
+              You've been invited to join <strong>{workspace?.name}</strong>.
+            </p>
+            <form method="post" action={`/w/${workspace?.slug}/invite/${code}`}>
+              <button type="submit" className="logout-button" style={{ fontSize: "1rem", padding: "0.5rem 1.5rem" }}>
+                Accept Invite
+              </button>
+            </form>
+          </div>
+        )}
+      </div>
+    </Layout>
   );
 }

--- a/hono/components/Layout.test.tsx
+++ b/hono/components/Layout.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { Layout } from "./Layout.js";
+
+describe("Layout component", () => {
+  it("should always include common.css before page-specific CSS", () => {
+    const html = (
+      <Layout title="Test" css="/test.css">
+        <div>content</div>
+      </Layout>
+    ).toString();
+
+    expect(html).toContain('href="/components/common.css"');
+    expect(html).toContain('href="/test.css"');
+    const commonIdx = html.indexOf('href="/components/common.css"');
+    const pageIdx = html.indexOf('href="/test.css"');
+    expect(commonIdx).toBeLessThan(pageIdx);
+  });
+
+  it("should render HTML document with title", () => {
+    const html = (
+      <Layout title="Test" css="/test.css">
+        <div>content</div>
+      </Layout>
+    ).toString();
+
+    expect(html).toContain('<html lang="en">');
+    expect(html).toContain("<title>Test - Mlack</title>");
+    expect(html).toContain('href="/test.css"');
+    expect(html).toContain("<div>content</div>");
+  });
+
+  it("should render multiple CSS files", () => {
+    const html = (
+      <Layout title="Multi" css={["/a.css", "/b.css"]}>
+        <div />
+      </Layout>
+    ).toString();
+
+    expect(html).toContain('href="/a.css"');
+    expect(html).toContain('href="/b.css"');
+  });
+
+  it("should render script tags at end of body", () => {
+    const html = (
+      <Layout title="Scripts" css="/test.css" scripts={["/a.js", "/b.js"]}>
+        <div>body</div>
+      </Layout>
+    ).toString();
+
+    expect(html).toContain('src="/a.js"');
+    expect(html).toContain('src="/b.js"');
+    const bodyIdx = html.indexOf("<div>body</div>");
+    const scriptIdx = html.indexOf('src="/a.js"');
+    expect(scriptIdx).toBeGreaterThan(bodyIdx);
+  });
+
+  it("should include viewport-fit=cover when viewportFit is true", () => {
+    const html = (
+      <Layout title="VP" css="/test.css" viewportFit>
+        <div />
+      </Layout>
+    ).toString();
+
+    expect(html).toContain("viewport-fit=cover");
+  });
+
+  it("should not include viewport-fit=cover by default", () => {
+    const html = (
+      <Layout title="VP" css="/test.css">
+        <div />
+      </Layout>
+    ).toString();
+
+    expect(html).not.toContain("viewport-fit");
+  });
+
+  it("should include charset and viewport meta tags", () => {
+    const html = (
+      <Layout title="Meta" css="/test.css">
+        <div />
+      </Layout>
+    ).toString();
+
+    expect(html).toContain('charSet="UTF-8"');
+    expect(html).toContain("width=device-width, initial-scale=1.0");
+  });
+});

--- a/hono/components/Layout.tsx
+++ b/hono/components/Layout.tsx
@@ -1,0 +1,35 @@
+import type { Child } from "hono/jsx";
+
+type LayoutProps = {
+  title: string;
+  css: string | string[];
+  scripts?: string[];
+  viewportFit?: boolean;
+  children: Child;
+};
+
+export function Layout({ title, css, scripts, viewportFit, children }: LayoutProps) {
+  const cssFiles = ["/components/common.css", ...(Array.isArray(css) ? css : [css])];
+  const viewportContent = viewportFit
+    ? "width=device-width, initial-scale=1.0, viewport-fit=cover"
+    : "width=device-width, initial-scale=1.0";
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content={viewportContent} />
+        <title>{title} - Mlack</title>
+        {cssFiles.map((href) => (
+          <link rel="stylesheet" href={href} />
+        ))}
+      </head>
+      <body>
+        {children}
+        {scripts?.map((src) => (
+          <script src={src} />
+        ))}
+      </body>
+    </html>
+  );
+}

--- a/hono/components/LoginPage.tsx
+++ b/hono/components/LoginPage.tsx
@@ -1,45 +1,39 @@
+import { Layout } from "./Layout.js";
+
 export async function LoginPage(error?: string) {
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Login - Mlack</title>
-        <link rel="stylesheet" href="/components/AuthPage.css" />
-      </head>
-      <body>
-        <div className="auth-container">
-          <h1 className="page-title">Login to Mlack</h1>
+    <Layout title="Login" css="/components/AuthPage.css">
+      <div className="auth-container">
+        <h1 className="page-title">Login to Mlack</h1>
 
-          {error && <div className="error-message">{error}</div>}
+        {error && <div className="error-message">{error}</div>}
 
-          <form method="post" action="/auth/login" className="auth-form">
-            <div className="form-group">
-              <label htmlFor="email">Email</label>
-              <input type="email" id="email" name="email" placeholder="you@example.com" required />
-            </div>
-            <div className="form-group">
-              <label htmlFor="password">Password</label>
-              <input type="password" id="password" name="password" placeholder="Your password" required />
-            </div>
-            <button type="submit" className="auth-button">
-              Login
-            </button>
-          </form>
-
-          <div className="auth-divider">
-            <span>or</span>
+        <form method="post" action="/auth/login" className="auth-form">
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input type="email" id="email" name="email" placeholder="you@example.com" required />
           </div>
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input type="password" id="password" name="password" placeholder="Your password" required />
+          </div>
+          <button type="submit" className="auth-button">
+            Login
+          </button>
+        </form>
 
-          <a href="/auth/google" className="google-button">
-            Login with Google
-          </a>
-
-          <p className="auth-link">
-            Don't have an account? <a href="/auth/register">Register</a>
-          </p>
+        <div className="auth-divider">
+          <span>or</span>
         </div>
-      </body>
-    </html>
+
+        <a href="/auth/google" className="google-button">
+          Login with Google
+        </a>
+
+        <p className="auth-link">
+          Don't have an account? <a href="/auth/register">Register</a>
+        </p>
+      </div>
+    </Layout>
   );
 }

--- a/hono/components/RegisterPage.tsx
+++ b/hono/components/RegisterPage.tsx
@@ -1,56 +1,50 @@
+import { Layout } from "./Layout.js";
+
 export async function RegisterPage(error?: string) {
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Register - Mlack</title>
-        <link rel="stylesheet" href="/components/AuthPage.css" />
-      </head>
-      <body>
-        <div className="auth-container">
-          <h1 className="page-title">Create an Account</h1>
+    <Layout title="Register" css="/components/AuthPage.css">
+      <div className="auth-container">
+        <h1 className="page-title">Create an Account</h1>
 
-          {error && <div className="error-message">{error}</div>}
+        {error && <div className="error-message">{error}</div>}
 
-          <form method="post" action="/auth/register" className="auth-form">
-            <div className="form-group">
-              <label htmlFor="name">Name</label>
-              <input type="text" id="name" name="name" placeholder="Your name" required />
-            </div>
-            <div className="form-group">
-              <label htmlFor="email">Email</label>
-              <input type="email" id="email" name="email" placeholder="you@example.com" required />
-            </div>
-            <div className="form-group">
-              <label htmlFor="password">Password</label>
-              <input
-                type="password"
-                id="password"
-                name="password"
-                placeholder="Choose a password (min 8 characters)"
-                required
-                minLength={8}
-              />
-            </div>
-            <button type="submit" className="auth-button">
-              Register
-            </button>
-          </form>
-
-          <div className="auth-divider">
-            <span>or</span>
+        <form method="post" action="/auth/register" className="auth-form">
+          <div className="form-group">
+            <label htmlFor="name">Name</label>
+            <input type="text" id="name" name="name" placeholder="Your name" required />
           </div>
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input type="email" id="email" name="email" placeholder="you@example.com" required />
+          </div>
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              placeholder="Choose a password (min 8 characters)"
+              required
+              minLength={8}
+            />
+          </div>
+          <button type="submit" className="auth-button">
+            Register
+          </button>
+        </form>
 
-          <a href="/auth/google" className="google-button">
-            Sign up with Google
-          </a>
-
-          <p className="auth-link">
-            Already have an account? <a href="/auth/login">Login</a>
-          </p>
+        <div className="auth-divider">
+          <span>or</span>
         </div>
-      </body>
-    </html>
+
+        <a href="/auth/google" className="google-button">
+          Sign up with Google
+        </a>
+
+        <p className="auth-link">
+          Already have an account? <a href="/auth/login">Login</a>
+        </p>
+      </div>
+    </Layout>
   );
 }

--- a/hono/components/VerifyEmailPage.tsx
+++ b/hono/components/VerifyEmailPage.tsx
@@ -1,3 +1,5 @@
+import { Layout } from "./Layout.js";
+
 type VerifyEmailPageProps = {
   email: string;
   error?: string;
@@ -6,62 +8,54 @@ type VerifyEmailPageProps = {
 
 export async function VerifyEmailPage({ email, error, success }: VerifyEmailPageProps) {
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Verify Email - Mlack</title>
-        <link rel="stylesheet" href="/components/AuthPage.css" />
-      </head>
-      <body>
-        <div className="auth-container">
-          <h1 className="page-title">Verify Your Email</h1>
+    <Layout title="Verify Email" css="/components/AuthPage.css">
+      <div className="auth-container">
+        <h1 className="page-title">Verify Your Email</h1>
 
-          <p className="verify-description">
-            We sent a 6-digit code to <strong>{email}</strong>. Enter it below to complete your registration.
-          </p>
+        <p className="verify-description">
+          We sent a 6-digit code to <strong>{email}</strong>. Enter it below to complete your registration.
+        </p>
 
-          {error && <div className="error-message">{error}</div>}
-          {success && <div className="success-message">{success}</div>}
+        {error && <div className="error-message">{error}</div>}
+        {success && <div className="success-message">{success}</div>}
 
-          <form method="post" action="/auth/verify-email" className="auth-form">
+        <form method="post" action="/auth/verify-email" className="auth-form">
+          <input type="hidden" name="email" value={email} />
+          <div className="form-group">
+            <label htmlFor="code">Verification Code</label>
+            <input
+              type="text"
+              id="code"
+              name="code"
+              placeholder="Enter 6-digit code"
+              required
+              maxLength={6}
+              minLength={6}
+              pattern="[0-9]{6}"
+              autoComplete="one-time-code"
+              inputMode="numeric"
+              className="verification-code-input"
+            />
+          </div>
+          <button type="submit" className="auth-button">
+            Verify
+          </button>
+        </form>
+
+        <div className="resend-section">
+          <p className="resend-text">Didn't receive the code?</p>
+          <form method="post" action="/auth/resend-code">
             <input type="hidden" name="email" value={email} />
-            <div className="form-group">
-              <label htmlFor="code">Verification Code</label>
-              <input
-                type="text"
-                id="code"
-                name="code"
-                placeholder="Enter 6-digit code"
-                required
-                maxLength={6}
-                minLength={6}
-                pattern="[0-9]{6}"
-                autoComplete="one-time-code"
-                inputMode="numeric"
-                className="verification-code-input"
-              />
-            </div>
-            <button type="submit" className="auth-button">
-              Verify
+            <button type="submit" className="resend-button">
+              Resend Code
             </button>
           </form>
-
-          <div className="resend-section">
-            <p className="resend-text">Didn't receive the code?</p>
-            <form method="post" action="/auth/resend-code">
-              <input type="hidden" name="email" value={email} />
-              <button type="submit" className="resend-button">
-                Resend Code
-              </button>
-            </form>
-          </div>
-
-          <p className="auth-link">
-            <a href="/auth/register">Back to registration</a>
-          </p>
         </div>
-      </body>
-    </html>
+
+        <p className="auth-link">
+          <a href="/auth/register">Back to registration</a>
+        </p>
+      </div>
+    </Layout>
   );
 }

--- a/hono/components/WorkspacesPage.css
+++ b/hono/components/WorkspacesPage.css
@@ -1,7 +1,4 @@
 body {
-  font-family: Arial, sans-serif;
-  margin: 0;
-  padding: 0;
   background-color: #f5f5f5;
 }
 
@@ -142,54 +139,29 @@ body {
 }
 
 .modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-}
-
-.modal.hidden {
-  display: none;
 }
 
 .modal-content {
   background-color: #fff;
-  border-radius: 8px;
-  padding: 24px;
   width: 420px;
-  max-width: 90vw;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
 }
 
 .modal-content h3 {
   color: #333;
   margin: 0 0 20px;
-  font-size: 18px;
 }
 
 .modal-label {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
   color: #555;
   margin-bottom: 4px;
 }
 
 .modal-content input {
-  width: 100%;
-  padding: 10px 12px;
   border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
   background-color: #fff;
   color: #333;
-  outline: none;
   margin-bottom: 12px;
   box-sizing: border-box;
 }
@@ -211,25 +183,6 @@ body {
   padding: 8px 12px;
   background-color: #fef2f2;
   border-radius: 4px;
-}
-
-.modal-error.hidden {
-  display: none;
-}
-
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.modal-actions button {
-  padding: 8px 16px;
-  border-radius: 4px;
-  font-size: 14px;
-  cursor: pointer;
-  border: none;
-  font-weight: 600;
 }
 
 #cancelCreateWorkspace {

--- a/hono/components/WorkspacesPage.tsx
+++ b/hono/components/WorkspacesPage.tsx
@@ -1,61 +1,55 @@
 import type { User, Workspace } from "../types.js";
 import { CreateWorkspaceModal } from "./CreateWorkspaceModal.js";
+import { Layout } from "./Layout.js";
 
 type WorkspaceWithRole = Workspace & { role: string };
 
 export async function WorkspacesPage(user: User, workspaceList: WorkspaceWithRole[]) {
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Workspaces - Mlack</title>
-        <link rel="stylesheet" href="/components/WorkspacesPage.css" />
-      </head>
-      <body>
-        <div className="workspaces-container">
-          <div className="workspaces-header">
-            <h1>Mlack Workspaces</h1>
-            <div className="user-info">
-              {user.picture && <img src={user.picture} alt="Profile" className="profile-picture" />}
-              <span className="user-email">{user.email}</span>
-              <form method="post" action="/auth/logout" style={{ display: "inline" }}>
-                <button type="submit" className="logout-button" title="Logout">
-                  Logout
-                </button>
-              </form>
-            </div>
+    <Layout
+      title="Workspaces"
+      css="/components/WorkspacesPage.css"
+      scripts={["/static/workspaceModal.js", "/static/WorkspacesPage.js"]}
+    >
+      <div className="workspaces-container">
+        <div className="workspaces-header">
+          <h1>Mlack Workspaces</h1>
+          <div className="user-info">
+            {user.picture && <img src={user.picture} alt="Profile" className="profile-picture" />}
+            <span className="user-email">{user.email}</span>
+            <form method="post" action="/auth/logout" style={{ display: "inline" }}>
+              <button type="submit" className="logout-button" title="Logout">
+                Logout
+              </button>
+            </form>
           </div>
-
-          <button type="button" id="createWorkspaceButton" className="create-workspace-button">
-            + Create Workspace
-          </button>
-
-          {workspaceList.length === 0 ? (
-            <div className="empty-state">
-              <p>You are not a member of any workspaces yet.</p>
-              <p>Create a new workspace or ask someone for an invite link.</p>
-            </div>
-          ) : (
-            <ul className="workspace-list">
-              {workspaceList.map((w) => (
-                <li className="workspace-item">
-                  <a href={`/w/${w.slug}`} className="workspace-link">
-                    <span className="workspace-name">{w.name}</span>
-                    <span className="workspace-slug">/{w.slug}</span>
-                    {w.role === "admin" && <span className="workspace-badge admin">Admin</span>}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
         </div>
 
-        {await CreateWorkspaceModal()}
+        <button type="button" id="createWorkspaceButton" className="create-workspace-button">
+          + Create Workspace
+        </button>
 
-        <script src="/static/workspaceModal.js"></script>
-        <script src="/static/WorkspacesPage.js"></script>
-      </body>
-    </html>
+        {workspaceList.length === 0 ? (
+          <div className="empty-state">
+            <p>You are not a member of any workspaces yet.</p>
+            <p>Create a new workspace or ask someone for an invite link.</p>
+          </div>
+        ) : (
+          <ul className="workspace-list">
+            {workspaceList.map((w) => (
+              <li className="workspace-item">
+                <a href={`/w/${w.slug}`} className="workspace-link">
+                  <span className="workspace-name">{w.name}</span>
+                  <span className="workspace-slug">/{w.slug}</span>
+                  {w.role === "admin" && <span className="workspace-badge admin">Admin</span>}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {await CreateWorkspaceModal()}
+    </Layout>
   );
 }

--- a/hono/components/common.css
+++ b/hono/components/common.css
@@ -1,0 +1,70 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 90vw;
+}
+
+.modal-content h3 {
+  font-size: 18px;
+}
+
+.modal-content input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.modal-actions button {
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  border: none;
+  font-weight: 600;
+}
+
+.modal-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.modal-error.hidden {
+  display: none;
+}

--- a/hono/db/queries/channel.test.ts
+++ b/hono/db/queries/channel.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getChannelByNameInWorkspace,
+  getChannelInWorkspace,
+  getChannelMemberEmails,
+  insertChannelMember,
+  isChannelMember,
+} from "./channel.js";
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockOnConflictDoNothing = vi.fn();
+const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+const mockDb = {
+  select: vi.fn().mockReturnValue({ from: mockFrom }),
+  insert: vi.fn().mockReturnValue({ values: mockValues }),
+} as never;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockValues.mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+  mockDb.insert.mockReturnValue({ values: mockValues });
+  mockWhere.mockReset();
+  mockOnConflictDoNothing.mockReset();
+});
+
+describe("isChannelMember", () => {
+  it("should return true when membership exists", async () => {
+    mockWhere.mockResolvedValue([{ id: 1, channelId: 1, userEmail: "user@example.com" }]);
+
+    const result = await isChannelMember(mockDb, 1, "user@example.com");
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false when membership does not exist", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await isChannelMember(mockDb, 1, "user@example.com");
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("getChannelInWorkspace", () => {
+  it("should return channel when found", async () => {
+    const channel = { id: 1, name: "general", workspaceId: 1 };
+    mockWhere.mockResolvedValue([channel]);
+
+    const result = await getChannelInWorkspace(mockDb, 1, 1);
+
+    expect(result).toEqual(channel);
+  });
+
+  it("should return null when not found", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await getChannelInWorkspace(mockDb, 999, 1);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getChannelByNameInWorkspace", () => {
+  it("should return channel when found by name", async () => {
+    const channel = { id: 1, name: "general", workspaceId: 1 };
+    mockWhere.mockResolvedValue([channel]);
+
+    const result = await getChannelByNameInWorkspace(mockDb, 1, "general");
+
+    expect(result).toEqual(channel);
+  });
+
+  it("should return null when name not found", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await getChannelByNameInWorkspace(mockDb, 1, "nonexistent");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("insertChannelMember", () => {
+  it("should insert a channel member", async () => {
+    mockOnConflictDoNothing.mockResolvedValue(undefined);
+
+    await insertChannelMember(mockDb, 1, "user@example.com");
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith({ channelId: 1, userEmail: "user@example.com" });
+    expect(mockOnConflictDoNothing).toHaveBeenCalled();
+  });
+});
+
+describe("getChannelMemberEmails", () => {
+  it("should return list of member emails", async () => {
+    mockWhere.mockResolvedValue([
+      { id: 1, channelId: 1, userEmail: "a@example.com", joinedAt: "2025-01-01" },
+      { id: 2, channelId: 1, userEmail: "b@example.com", joinedAt: "2025-01-01" },
+    ]);
+
+    const result = await getChannelMemberEmails(mockDb, 1);
+
+    expect(result).toEqual(["a@example.com", "b@example.com"]);
+  });
+
+  it("should return empty array when no members", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await getChannelMemberEmails(mockDb, 1);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/hono/db/queries/channel.test.ts
+++ b/hono/db/queries/channel.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ensureGeneralChannelMembership,
   getChannelByNameInWorkspace,
   getChannelInWorkspace,
   getChannelMemberEmails,
@@ -112,5 +113,34 @@ describe("getChannelMemberEmails", () => {
     const result = await getChannelMemberEmails(mockDb, 1);
 
     expect(result).toEqual([]);
+  });
+});
+
+describe("ensureGeneralChannelMembership", () => {
+  it("should join general channel when not already a member", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: 5, name: "general", workspaceId: 1 }]);
+    mockWhere.mockResolvedValueOnce([]);
+    mockOnConflictDoNothing.mockResolvedValue(undefined);
+
+    await ensureGeneralChannelMembership(mockDb, 1, "user@example.com");
+
+    expect(mockDb.insert).toHaveBeenCalled();
+  });
+
+  it("should skip insert when already a member", async () => {
+    mockWhere.mockResolvedValueOnce([{ id: 5, name: "general", workspaceId: 1 }]);
+    mockWhere.mockResolvedValueOnce([{ channelId: 5, userEmail: "user@example.com" }]);
+
+    await ensureGeneralChannelMembership(mockDb, 1, "user@example.com");
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing when general channel does not exist", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    await ensureGeneralChannelMembership(mockDb, 1, "user@example.com");
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
   });
 });

--- a/hono/db/queries/channel.ts
+++ b/hono/db/queries/channel.ts
@@ -1,0 +1,36 @@
+import { and, eq } from "drizzle-orm";
+import { channelMembers, channels } from "../schema.js";
+import type { Database } from "./types.js";
+
+export async function isChannelMember(db: Database, channelId: number, userEmail: string): Promise<boolean> {
+  const membership = await db
+    .select()
+    .from(channelMembers)
+    .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, userEmail)));
+  return membership.length > 0;
+}
+
+export async function getChannelInWorkspace(db: Database, channelId: number, workspaceId: number) {
+  const [channel] = await db
+    .select()
+    .from(channels)
+    .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspaceId)));
+  return channel ?? null;
+}
+
+export async function getChannelByNameInWorkspace(db: Database, workspaceId: number, name: string) {
+  const [channel] = await db
+    .select()
+    .from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), eq(channels.name, name)));
+  return channel ?? null;
+}
+
+export async function insertChannelMember(db: Database, channelId: number, userEmail: string): Promise<void> {
+  await db.insert(channelMembers).values({ channelId, userEmail }).onConflictDoNothing();
+}
+
+export async function getChannelMemberEmails(db: Database, channelId: number): Promise<string[]> {
+  const members = await db.select().from(channelMembers).where(eq(channelMembers.channelId, channelId));
+  return members.map((m) => m.userEmail);
+}

--- a/hono/db/queries/channel.ts
+++ b/hono/db/queries/channel.ts
@@ -34,3 +34,17 @@ export async function getChannelMemberEmails(db: Database, channelId: number): P
   const members = await db.select().from(channelMembers).where(eq(channelMembers.channelId, channelId));
   return members.map((m) => m.userEmail);
 }
+
+export async function ensureGeneralChannelMembership(
+  db: Database,
+  workspaceId: number,
+  userEmail: string,
+): Promise<void> {
+  const generalChannel = await getChannelByNameInWorkspace(db, workspaceId, "general");
+  if (!generalChannel) return;
+
+  const alreadyMember = await isChannelMember(db, generalChannel.id, userEmail);
+  if (!alreadyMember) {
+    await insertChannelMember(db, generalChannel.id, userEmail);
+  }
+}

--- a/hono/db/queries/conversation.test.ts
+++ b/hono/db/queries/conversation.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getConversationForParticipant } from "./conversation.js";
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockDb = {
+  select: vi.fn(() => ({ from: mockFrom })),
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFrom.mockReturnValue({ where: mockWhere });
+});
+
+describe("getConversationForParticipant", () => {
+  it("should return conversation when user is a participant", async () => {
+    const conversation = { id: 1, workspaceId: 1, user1Email: "a@example.com", user2Email: "b@example.com" };
+    mockWhere.mockResolvedValue([conversation]);
+
+    const result = await getConversationForParticipant(mockDb, 1, "a@example.com");
+
+    expect(result).toEqual(conversation);
+  });
+
+  it("should return null when user is not a participant", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await getConversationForParticipant(mockDb, 1, "stranger@example.com");
+
+    expect(result).toBeNull();
+  });
+
+  it("should include workspaceId in query when provided", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    await getConversationForParticipant(mockDb, 1, "a@example.com", 5);
+
+    expect(mockWhere).toHaveBeenCalled();
+  });
+});

--- a/hono/db/queries/conversation.ts
+++ b/hono/db/queries/conversation.ts
@@ -1,0 +1,27 @@
+import { and, eq, or } from "drizzle-orm";
+import { directConversations } from "../schema.js";
+import type { Database } from "./types.js";
+
+export async function getConversationForParticipant(
+  db: Database,
+  conversationId: number,
+  userEmail: string,
+  workspaceId?: number,
+) {
+  const participantCondition = or(
+    eq(directConversations.user1Email, userEmail),
+    eq(directConversations.user2Email, userEmail),
+  );
+
+  const whereCondition =
+    workspaceId !== undefined
+      ? and(
+          eq(directConversations.id, conversationId),
+          eq(directConversations.workspaceId, workspaceId),
+          participantCondition,
+        )
+      : and(eq(directConversations.id, conversationId), participantCondition);
+
+  const [conversation] = await db.select().from(directConversations).where(whereCondition);
+  return conversation ?? null;
+}

--- a/hono/db/queries/index.ts
+++ b/hono/db/queries/index.ts
@@ -1,4 +1,5 @@
 export {
+  ensureGeneralChannelMembership,
   getChannelByNameInWorkspace,
   getChannelInWorkspace,
   getChannelMemberEmails,

--- a/hono/db/queries/index.ts
+++ b/hono/db/queries/index.ts
@@ -1,0 +1,11 @@
+export {
+  getChannelByNameInWorkspace,
+  getChannelInWorkspace,
+  getChannelMemberEmails,
+  insertChannelMember,
+  isChannelMember,
+} from "./channel.js";
+export { getConversationForParticipant } from "./conversation.js";
+export type { Database } from "./types.js";
+export { getUserNameByEmail, getUsersByEmails } from "./user.js";
+export { getWorkspaceMember } from "./workspace.js";

--- a/hono/db/queries/types.ts
+++ b/hono/db/queries/types.ts
@@ -1,0 +1,4 @@
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type * as schema from "../schema.js";
+
+export type Database = DrizzleD1Database<typeof schema>;

--- a/hono/db/queries/user.test.ts
+++ b/hono/db/queries/user.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserNameByEmail, getUsersByEmails } from "./user.js";
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockDb = {
+  select: vi.fn(() => ({ from: mockFrom })),
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFrom.mockReturnValue({ where: mockWhere });
+});
+
+describe("getUserNameByEmail", () => {
+  it("should return user name when found", async () => {
+    mockWhere.mockResolvedValue([{ name: "Alice" }]);
+
+    const result = await getUserNameByEmail(mockDb, "alice@example.com");
+
+    expect(result).toBe("Alice");
+  });
+
+  it("should return null when user not found", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await getUserNameByEmail(mockDb, "unknown@example.com");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getUsersByEmails", () => {
+  it("should return users matching the emails", async () => {
+    const users = [
+      { email: "a@example.com", name: "Alice" },
+      { email: "b@example.com", name: "Bob" },
+    ];
+    mockWhere.mockResolvedValue(users);
+
+    const result = await getUsersByEmails(mockDb, ["a@example.com", "b@example.com"]);
+
+    expect(result).toEqual(users);
+  });
+
+  it("should return empty array for empty email list", async () => {
+    const result = await getUsersByEmails(mockDb, []);
+
+    expect(result).toEqual([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});

--- a/hono/db/queries/user.ts
+++ b/hono/db/queries/user.ts
@@ -1,0 +1,16 @@
+import { eq, inArray } from "drizzle-orm";
+import { users } from "../schema.js";
+import type { Database } from "./types.js";
+
+export async function getUserNameByEmail(db: Database, email: string): Promise<string | null> {
+  const [user] = await db.select({ name: users.name }).from(users).where(eq(users.email, email));
+  return user?.name ?? null;
+}
+
+export async function getUsersByEmails(
+  db: Database,
+  emails: string[],
+): Promise<Array<{ email: string; name: string }>> {
+  if (emails.length === 0) return [];
+  return db.select({ email: users.email, name: users.name }).from(users).where(inArray(users.email, emails));
+}

--- a/hono/db/queries/workspace.test.ts
+++ b/hono/db/queries/workspace.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getWorkspaceMember } from "./workspace.js";
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockDb = {
+  select: vi.fn(() => ({ from: mockFrom })),
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFrom.mockReturnValue({ where: mockWhere });
+});
+
+describe("getWorkspaceMember", () => {
+  it("should return member when found", async () => {
+    const member = { id: 1, workspaceId: 1, userEmail: "user@example.com", role: "member", joinedAt: "2025-01-01" };
+    mockWhere.mockResolvedValue([member]);
+
+    const result = await getWorkspaceMember(mockDb, 1, "user@example.com");
+
+    expect(result).toEqual(member);
+  });
+
+  it("should return null when member not found", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const result = await getWorkspaceMember(mockDb, 1, "stranger@example.com");
+
+    expect(result).toBeNull();
+  });
+});

--- a/hono/db/queries/workspace.ts
+++ b/hono/db/queries/workspace.ts
@@ -1,0 +1,11 @@
+import { and, eq } from "drizzle-orm";
+import { workspaceMembers } from "../schema.js";
+import type { Database } from "./types.js";
+
+export async function getWorkspaceMember(db: Database, workspaceId: number, userEmail: string) {
+  const [member] = await db
+    .select()
+    .from(workspaceMembers)
+    .where(and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.userEmail, userEmail)));
+  return member ?? null;
+}

--- a/hono/durableObjects/ChatRoom.ts
+++ b/hono/durableObjects/ChatRoom.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
-import { and, eq, or } from "drizzle-orm";
-import { channelMembers, directConversations, directMessages, getDb, messages } from "../db/index.js";
+import { directMessages, getDb, messages } from "../db/index.js";
+import { getChannelMemberEmails, getConversationForParticipant, isChannelMember } from "../db/queries/index.js";
 import type { Bindings } from "../types.js";
 
 type SessionAttachment = {
@@ -143,12 +143,9 @@ export class ChatRoom extends DurableObject<Bindings> {
 
     const db = getDb(this.env.DB);
 
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, attachment.userEmail)));
+    const isMember = await isChannelMember(db, channelId, attachment.userEmail);
 
-    if (membership.length === 0) {
+    if (!isMember) {
       try {
         ws.send(JSON.stringify({ type: "error", error: "Not a member of this channel" }));
       } catch {
@@ -185,8 +182,8 @@ export class ChatRoom extends DurableObject<Bindings> {
     });
 
     try {
-      const members = await db.select().from(channelMembers).where(eq(channelMembers.channelId, channelId));
-      const memberEmails = new Set(members.map((m) => m.userEmail));
+      const memberEmailsList = await getChannelMemberEmails(db, channelId);
+      const memberEmails = new Set(memberEmailsList);
       const allSockets = this.ctx.getWebSockets();
 
       for (const socket of allSockets) {
@@ -227,20 +224,9 @@ export class ChatRoom extends DurableObject<Bindings> {
     const trimmedContent = dm.content?.trim() || "";
     const db = getDb(this.env.DB);
 
-    const conversation = await db
-      .select()
-      .from(directConversations)
-      .where(
-        and(
-          eq(directConversations.id, dm.conversationId),
-          or(
-            eq(directConversations.user1Email, sender.userEmail),
-            eq(directConversations.user2Email, sender.userEmail),
-          ),
-        ),
-      );
+    const conv = await getConversationForParticipant(db, dm.conversationId, sender.userEmail);
 
-    if (conversation.length === 0) {
+    if (!conv) {
       try {
         ws.send(JSON.stringify({ type: "error", error: "Not a participant in this conversation" }));
       } catch {
@@ -248,8 +234,6 @@ export class ChatRoom extends DurableObject<Bindings> {
       }
       return;
     }
-
-    const conv = conversation[0];
 
     try {
       await db.insert(directMessages).values({
@@ -316,20 +300,9 @@ export class ChatRoom extends DurableObject<Bindings> {
     if (!otherEmail) {
       const db = getDb(this.env.DB);
 
-      const conversation = await db
-        .select()
-        .from(directConversations)
-        .where(
-          and(
-            eq(directConversations.id, signal.conversationId),
-            or(
-              eq(directConversations.user1Email, sender.userEmail),
-              eq(directConversations.user2Email, sender.userEmail),
-            ),
-          ),
-        );
+      const conv = await getConversationForParticipant(db, signal.conversationId, sender.userEmail);
 
-      if (conversation.length === 0) {
+      if (!conv) {
         try {
           ws.send(JSON.stringify({ type: "error", error: "Not a participant in this conversation" }));
         } catch {
@@ -338,7 +311,6 @@ export class ChatRoom extends DurableObject<Bindings> {
         return;
       }
 
-      const conv = conversation[0];
       otherEmail = conv.user1Email === sender.userEmail ? conv.user2Email : conv.user1Email;
       if (this.dmAuthCache.size >= 1000) {
         this.dmAuthCache.clear();
@@ -379,8 +351,8 @@ export class ChatRoom extends DurableObject<Bindings> {
 
     try {
       const db = getDb(this.env.DB);
-      const members = await db.select().from(channelMembers).where(eq(channelMembers.channelId, event.channelId));
-      const memberEmails = new Set(members.map((m) => m.userEmail));
+      const memberEmailsList = await getChannelMemberEmails(db, event.channelId);
+      const memberEmails = new Set(memberEmailsList);
 
       if (event.type === "memberJoin") {
         memberEmails.add(event.userEmail);

--- a/hono/helpers/parsePositiveInt.test.ts
+++ b/hono/helpers/parsePositiveInt.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parsePositiveInt } from "./parsePositiveInt.js";
+
+describe("parsePositiveInt", () => {
+  it("should parse valid positive integers", () => {
+    expect(parsePositiveInt("1")).toBe(1);
+    expect(parsePositiveInt("42")).toBe(42);
+    expect(parsePositiveInt("100")).toBe(100);
+  });
+
+  it("should return null for non-numeric strings", () => {
+    expect(parsePositiveInt("abc")).toBeNull();
+    expect(parsePositiveInt("")).toBeNull();
+    expect(parsePositiveInt(undefined)).toBeNull();
+    expect(parsePositiveInt(null)).toBeNull();
+  });
+
+  it("should return null for zero and negative numbers", () => {
+    expect(parsePositiveInt("0")).toBeNull();
+    expect(parsePositiveInt("-1")).toBeNull();
+    expect(parsePositiveInt("-100")).toBeNull();
+  });
+
+  it("should return null for floating point numbers", () => {
+    expect(parsePositiveInt("1.5")).toBeNull();
+    expect(parsePositiveInt("3.14")).toBeNull();
+  });
+
+  it("should handle numeric inputs directly", () => {
+    expect(parsePositiveInt(5)).toBe(5);
+    expect(parsePositiveInt(0)).toBeNull();
+    expect(parsePositiveInt(-3)).toBeNull();
+    expect(parsePositiveInt(1.7)).toBeNull();
+  });
+});

--- a/hono/helpers/parsePositiveInt.ts
+++ b/hono/helpers/parsePositiveInt.ts
@@ -1,0 +1,5 @@
+export function parsePositiveInt(value: unknown): number | null {
+  const num = Number(value);
+  if (Number.isNaN(num) || !Number.isInteger(num) || num <= 0) return null;
+  return num;
+}

--- a/hono/routes/channels.test.ts
+++ b/hono/routes/channels.test.ts
@@ -152,6 +152,11 @@ describe("Channels API", () => {
       });
       mockSelect.mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ channelId: 1, userEmail: "test@example.com" }]),
+        }),
+      });
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([{ userEmail: "test@example.com" }, { userEmail: "other@example.com" }]),
         }),
       });
@@ -182,7 +187,7 @@ describe("Channels API", () => {
       });
       mockSelect.mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{ userEmail: "other@example.com" }]),
+          where: vi.fn().mockResolvedValue([]),
         }),
       });
 

--- a/hono/routes/channels.test.ts
+++ b/hono/routes/channels.test.ts
@@ -248,7 +248,9 @@ describe("Channels API", () => {
         }),
       });
       mockInsert.mockReturnValueOnce({
-        values: vi.fn().mockResolvedValue({}),
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({}),
+        }),
       });
 
       const { app } = createTestApp({ authenticatedUser });
@@ -322,7 +324,9 @@ describe("Channels API", () => {
         }),
       });
       mockInsert.mockReturnValue({
-        values: vi.fn().mockResolvedValue({}),
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockResolvedValue({}),
+        }),
       });
 
       const { app } = createTestApp({ authenticatedUser });

--- a/hono/routes/channels.ts
+++ b/hono/routes/channels.ts
@@ -8,6 +8,7 @@ import {
   isChannelMember,
 } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
+import { parsePositiveInt } from "../helpers/parsePositiveInt.js";
 import type { Env } from "../types.js";
 
 const channelsRoute = new Hono<Env>();
@@ -55,8 +56,8 @@ channelsRoute.get("/w/:slug/api/channels/:id/members", async (c) => {
     const user = c.get("user");
     const workspace = getWorkspace(c);
 
-    const channelId = Number(c.req.param("id"));
-    if (Number.isNaN(channelId)) {
+    const channelId = parsePositiveInt(c.req.param("id"));
+    if (!channelId) {
       return c.json({ error: "Invalid channel ID" }, 400);
     }
 
@@ -65,15 +66,15 @@ channelsRoute.get("/w/:slug/api/channels/:id/members", async (c) => {
       return c.json({ error: "Channel not found" }, 404);
     }
 
+    const isMember = await isChannelMember(db, channelId, user.email);
+    if (!isMember) {
+      return c.json({ error: "Not a member of this channel" }, 403);
+    }
+
     const memberships = await db
       .select({ userEmail: channelMembers.userEmail })
       .from(channelMembers)
       .where(eq(channelMembers.channelId, channelId));
-
-    const isMember = memberships.some((m) => m.userEmail === user.email);
-    if (!isMember) {
-      return c.json({ error: "Not a member of this channel" }, 403);
-    }
 
     const memberEmails = memberships.map((m) => m.userEmail);
     const memberUsers =
@@ -129,8 +130,8 @@ channelsRoute.post("/w/:slug/api/channels/:id/join", async (c) => {
     const user = c.get("user");
     const workspace = getWorkspace(c);
 
-    const channelId = Number(c.req.param("id"));
-    if (Number.isNaN(channelId)) {
+    const channelId = parsePositiveInt(c.req.param("id"));
+    if (!channelId) {
       return c.json({ error: "Invalid channel ID" }, 400);
     }
 
@@ -160,8 +161,8 @@ channelsRoute.post("/w/:slug/api/channels/:id/leave", async (c) => {
     const user = c.get("user");
     const workspace = getWorkspace(c);
 
-    const channelId = Number(c.req.param("id"));
-    if (Number.isNaN(channelId)) {
+    const channelId = parsePositiveInt(c.req.param("id"));
+    if (!channelId) {
       return c.json({ error: "Invalid channel ID" }, 400);
     }
 

--- a/hono/routes/channels.ts
+++ b/hono/routes/channels.ts
@@ -1,6 +1,12 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import { channelMembers, channels, getDb, users } from "../db/index.js";
+import {
+  getChannelByNameInWorkspace,
+  getChannelInWorkspace,
+  insertChannelMember,
+  isChannelMember,
+} from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import type { Env } from "../types.js";
 
@@ -54,11 +60,8 @@ channelsRoute.get("/w/:slug/api/channels/:id/members", async (c) => {
       return c.json({ error: "Invalid channel ID" }, 400);
     }
 
-    const channel = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)));
-    if (channel.length === 0) {
+    const channel = await getChannelInWorkspace(db, channelId, workspace.id);
+    if (!channel) {
       return c.json({ error: "Channel not found" }, 404);
     }
 
@@ -101,11 +104,8 @@ channelsRoute.post("/w/:slug/api/channels", async (c) => {
       return c.json({ error: "Channel name is required" }, 400);
     }
 
-    const existing = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.workspaceId, workspace.id), eq(channels.name, name)));
-    if (existing.length > 0) {
+    const existing = await getChannelByNameInWorkspace(db, workspace.id, name);
+    if (existing) {
       return c.json({ error: "Channel name already exists" }, 409);
     }
 
@@ -114,7 +114,7 @@ channelsRoute.post("/w/:slug/api/channels", async (c) => {
       .values({ name, workspaceId: workspace.id, createdByEmail: user.email })
       .returning();
 
-    await db.insert(channelMembers).values({ channelId: created.id, userEmail: user.email });
+    await insertChannelMember(db, created.id, user.email);
 
     return c.json({ channel: created }, 201);
   } catch (error) {
@@ -134,24 +134,18 @@ channelsRoute.post("/w/:slug/api/channels/:id/join", async (c) => {
       return c.json({ error: "Invalid channel ID" }, 400);
     }
 
-    const channel = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)));
-    if (channel.length === 0) {
+    const channel = await getChannelInWorkspace(db, channelId, workspace.id);
+    if (!channel) {
       return c.json({ error: "Channel not found" }, 404);
     }
 
-    const existingMember = await db
-      .select()
-      .from(channelMembers)
-      .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)));
+    const alreadyMember = await isChannelMember(db, channelId, user.email);
 
-    if (existingMember.length > 0) {
+    if (alreadyMember) {
       return c.json({ message: "Already a member" }, 200);
     }
 
-    await db.insert(channelMembers).values({ channelId, userEmail: user.email });
+    await insertChannelMember(db, channelId, user.email);
 
     return c.json({ message: "Joined channel" }, 200);
   } catch (error) {
@@ -171,15 +165,12 @@ channelsRoute.post("/w/:slug/api/channels/:id/leave", async (c) => {
       return c.json({ error: "Invalid channel ID" }, 400);
     }
 
-    const channel = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)));
-    if (channel.length === 0) {
+    const channel = await getChannelInWorkspace(db, channelId, workspace.id);
+    if (!channel) {
       return c.json({ error: "Channel not found" }, 404);
     }
 
-    if (channel[0].name === "general") {
+    if (channel.name === "general") {
       return c.json({ error: "Cannot leave #general" }, 403);
     }
 

--- a/hono/routes/directMessages.ts
+++ b/hono/routes/directMessages.ts
@@ -1,6 +1,7 @@
-import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
-import { directConversations, directMessages, getDb, users, workspaceMembers } from "../db/index.js";
+import { directConversations, directMessages, getDb, workspaceMembers } from "../db/index.js";
+import { getUserNameByEmail, getUsersByEmails, getWorkspaceMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import type { Env } from "../types.js";
 
@@ -26,10 +27,7 @@ directMessagesRoute.get("/w/:slug/api/dm/conversations", async (c) => {
       conv.user1Email === user.email ? conv.user2Email : conv.user1Email,
     );
 
-    const otherUsers =
-      otherEmails.length > 0
-        ? await db.select({ email: users.email, name: users.name }).from(users).where(inArray(users.email, otherEmails))
-        : [];
+    const otherUsers = await getUsersByEmails(db, otherEmails);
 
     const userMap = new Map(otherUsers.map((u) => [u.email, u.name]));
 
@@ -67,12 +65,9 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
       return c.json({ error: "Cannot start a DM with yourself" }, 400);
     }
 
-    const targetMembership = await db
-      .select()
-      .from(workspaceMembers)
-      .where(and(eq(workspaceMembers.workspaceId, workspace.id), eq(workspaceMembers.userEmail, targetEmail)));
+    const targetMembership = await getWorkspaceMember(db, workspace.id, targetEmail);
 
-    if (targetMembership.length === 0) {
+    if (!targetMembership) {
       return c.json({ error: "User is not a member of this workspace" }, 404);
     }
 
@@ -92,8 +87,7 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
     if (existing.length > 0) {
       const conv = existing[0];
       const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
-      const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
-      const otherUserName = targetUser.length > 0 ? targetUser[0].name : otherEmail;
+      const otherUserName = (await getUserNameByEmail(db, otherEmail)) ?? otherEmail;
 
       return c.json({
         conversation: {
@@ -130,8 +124,7 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
       if (raceExisting.length > 0) {
         const conv = raceExisting[0];
         const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
-        const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
-        const otherUserName = targetUser.length > 0 ? targetUser[0].name : otherEmail;
+        const otherUserName = (await getUserNameByEmail(db, otherEmail)) ?? otherEmail;
 
         return c.json({
           conversation: {
@@ -147,8 +140,7 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
     }
 
     const otherEmail = created.user1Email === user.email ? created.user2Email : created.user1Email;
-    const targetUser = await db.select({ name: users.name }).from(users).where(eq(users.email, otherEmail));
-    const otherUserName = targetUser.length > 0 ? targetUser[0].name : otherEmail;
+    const otherUserName = (await getUserNameByEmail(db, otherEmail)) ?? otherEmail;
 
     return c.json(
       {
@@ -219,13 +211,7 @@ directMessagesRoute.get("/w/:slug/api/dm/workspace-members", async (c) => {
 
     const memberEmails = members.map((m) => m.userEmail).filter((email) => email !== user.email);
 
-    const memberUsers =
-      memberEmails.length > 0
-        ? await db
-            .select({ email: users.email, name: users.name })
-            .from(users)
-            .where(inArray(users.email, memberEmails))
-        : [];
+    const memberUsers = await getUsersByEmails(db, memberEmails);
 
     return c.json({ members: memberUsers });
   } catch (error) {

--- a/hono/routes/directMessages.ts
+++ b/hono/routes/directMessages.ts
@@ -3,9 +3,31 @@ import { Hono } from "hono";
 import { directConversations, directMessages, getDb, workspaceMembers } from "../db/index.js";
 import { getUserNameByEmail, getUsersByEmails, getWorkspaceMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
+import { parsePositiveInt } from "../helpers/parsePositiveInt.js";
 import type { Env } from "../types.js";
 
 const directMessagesRoute = new Hono<Env>();
+
+type ConversationResponse = {
+  id: number;
+  otherUserEmail: string;
+  otherUserName: string;
+  createdAt: string | null;
+};
+
+function formatConversation(
+  conv: { id: number; user1Email: string; user2Email: string; createdAt: string | null },
+  currentUserEmail: string,
+  otherUserName: string,
+): ConversationResponse {
+  const otherEmail = conv.user1Email === currentUserEmail ? conv.user2Email : conv.user1Email;
+  return {
+    id: conv.id,
+    otherUserEmail: otherEmail,
+    otherUserName,
+    createdAt: conv.createdAt,
+  };
+}
 
 directMessagesRoute.get("/w/:slug/api/dm/conversations", async (c) => {
   try {
@@ -33,12 +55,7 @@ directMessagesRoute.get("/w/:slug/api/dm/conversations", async (c) => {
 
     const result = conversations.map((conv) => {
       const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
-      return {
-        id: conv.id,
-        otherUserEmail: otherEmail,
-        otherUserName: userMap.get(otherEmail) || otherEmail,
-        createdAt: conv.createdAt,
-      };
+      return formatConversation(conv, user.email, userMap.get(otherEmail) || otherEmail);
     });
 
     return c.json({ conversations: result });
@@ -89,14 +106,7 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
       const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
       const otherUserName = (await getUserNameByEmail(db, otherEmail)) ?? otherEmail;
 
-      return c.json({
-        conversation: {
-          id: conv.id,
-          otherUserEmail: otherEmail,
-          otherUserName,
-          createdAt: conv.createdAt,
-        },
-      });
+      return c.json({ conversation: formatConversation(conv, user.email, otherUserName) });
     }
 
     let created: (typeof existing)[0];
@@ -126,14 +136,7 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
         const otherEmail = conv.user1Email === user.email ? conv.user2Email : conv.user1Email;
         const otherUserName = (await getUserNameByEmail(db, otherEmail)) ?? otherEmail;
 
-        return c.json({
-          conversation: {
-            id: conv.id,
-            otherUserEmail: otherEmail,
-            otherUserName,
-            createdAt: conv.createdAt,
-          },
-        });
+        return c.json({ conversation: formatConversation(conv, user.email, otherUserName) });
       }
 
       throw insertError;
@@ -142,17 +145,7 @@ directMessagesRoute.post("/w/:slug/api/dm/conversations", async (c) => {
     const otherEmail = created.user1Email === user.email ? created.user2Email : created.user1Email;
     const otherUserName = (await getUserNameByEmail(db, otherEmail)) ?? otherEmail;
 
-    return c.json(
-      {
-        conversation: {
-          id: created.id,
-          otherUserEmail: otherEmail,
-          otherUserName,
-          createdAt: created.createdAt,
-        },
-      },
-      201,
-    );
+    return c.json({ conversation: formatConversation(created, user.email, otherUserName) }, 201);
   } catch (error) {
     console.error("Error creating DM conversation:", error);
     return c.json({ error: "Failed to create conversation" }, 500);
@@ -165,8 +158,8 @@ directMessagesRoute.get("/w/:slug/api/dm/conversations/:id/messages", async (c) 
     const user = c.get("user");
     const workspace = getWorkspace(c);
 
-    const conversationId = Number(c.req.param("id"));
-    if (Number.isNaN(conversationId)) {
+    const conversationId = parsePositiveInt(c.req.param("id"));
+    if (!conversationId) {
       return c.json({ error: "Invalid conversation ID" }, 400);
     }
 

--- a/hono/routes/emailAuth.ts
+++ b/hono/routes/emailAuth.ts
@@ -75,7 +75,7 @@ emailAuthRoute.post("/auth/login", loginRateLimiter, async (c) => {
   try {
     const body = await c.req.parseBody();
     const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
-    const password = body.password as string;
+    const password = typeof body.password === "string" ? body.password : "";
 
     if (!email || !password) {
       return renderPage(c, LoginPage("Email and password are required."), 400);
@@ -122,7 +122,7 @@ emailAuthRoute.post("/auth/register", registerRateLimiter, async (c) => {
     const body = await c.req.parseBody();
     const name = typeof body.name === "string" ? body.name.trim() : "";
     const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
-    const password = body.password as string;
+    const password = typeof body.password === "string" ? body.password : "";
 
     if (!name || !email || !password) {
       return renderPage(c, RegisterPage("All fields are required."), 400);
@@ -173,9 +173,10 @@ emailAuthRoute.get("/auth/verify-email", async (c) => {
 });
 
 emailAuthRoute.post("/auth/verify-email", verifyRateLimiter, async (c) => {
+  let email = "";
   try {
     const body = await c.req.parseBody();
-    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
     const code = typeof body.code === "string" ? body.code.trim() : "";
 
     if (!email || !code) {
@@ -231,16 +232,15 @@ emailAuthRoute.post("/auth/verify-email", verifyRateLimiter, async (c) => {
     return c.redirect("/");
   } catch (error) {
     console.error("Verification error:", error);
-    const body = await c.req.parseBody().catch(() => ({}));
-    const email = (body as Record<string, string>).email || "";
     return renderPage(c, VerifyEmailPage({ email, error: "Verification failed. Please try again." }), 500);
   }
 });
 
 emailAuthRoute.post("/auth/resend-code", resendRateLimiter, async (c) => {
+  let email = "";
   try {
     const body = await c.req.parseBody();
-    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
 
     if (!email) {
       return c.redirect("/auth/register");
@@ -281,8 +281,6 @@ emailAuthRoute.post("/auth/resend-code", resendRateLimiter, async (c) => {
     return renderPage(c, VerifyEmailPage({ email, success: "A new verification code has been sent." }));
   } catch (error) {
     console.error("Resend code error:", error);
-    const body = await c.req.parseBody().catch(() => ({}));
-    const email = (body as Record<string, string>).email || "";
     return renderPage(c, VerifyEmailPage({ email, error: "Failed to resend code. Please try again." }), 500);
   }
 });

--- a/hono/routes/index.tsx
+++ b/hono/routes/index.tsx
@@ -4,7 +4,7 @@ import { AboutPage } from "../components/AboutPage.js";
 import { ChatPage } from "../components/ChatPage.js";
 import { WorkspacesPage } from "../components/WorkspacesPage.js";
 import { getDb, workspaceMembers, workspaces } from "../db/index.js";
-import { getChannelByNameInWorkspace, insertChannelMember, isChannelMember } from "../db/queries/index.js";
+import { ensureGeneralChannelMembership } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import { renderPage } from "../helpers/renderPage.js";
 import type { Env, User } from "../types.js";
@@ -85,15 +85,7 @@ indexRoute.get("/w/:slug", async (c) => {
 
   try {
     const db = getDb(c.env.DB);
-    const generalChannel = await getChannelByNameInWorkspace(db, workspace.id, "general");
-
-    if (generalChannel) {
-      const alreadyMember = await isChannelMember(db, generalChannel.id, user.email);
-
-      if (!alreadyMember) {
-        await insertChannelMember(db, generalChannel.id, user.email);
-      }
-    }
+    await ensureGeneralChannelMembership(db, workspace.id, user.email);
   } catch (error) {
     console.error("Error auto-joining #general:", error);
   }

--- a/hono/routes/index.tsx
+++ b/hono/routes/index.tsx
@@ -1,9 +1,10 @@
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { AboutPage } from "../components/AboutPage.js";
 import { ChatPage } from "../components/ChatPage.js";
 import { WorkspacesPage } from "../components/WorkspacesPage.js";
-import { channelMembers, channels, getDb, workspaceMembers, workspaces } from "../db/index.js";
+import { getDb, workspaceMembers, workspaces } from "../db/index.js";
+import { getChannelByNameInWorkspace, insertChannelMember, isChannelMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import { renderPage } from "../helpers/renderPage.js";
 import type { Env, User } from "../types.js";
@@ -84,22 +85,13 @@ indexRoute.get("/w/:slug", async (c) => {
 
   try {
     const db = getDb(c.env.DB);
-    const [generalChannel] = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.workspaceId, workspace.id), eq(channels.name, "general")));
+    const generalChannel = await getChannelByNameInWorkspace(db, workspace.id, "general");
 
     if (generalChannel) {
-      const existingMembership = await db
-        .select()
-        .from(channelMembers)
-        .where(and(eq(channelMembers.channelId, generalChannel.id), eq(channelMembers.userEmail, user.email)));
+      const alreadyMember = await isChannelMember(db, generalChannel.id, user.email);
 
-      if (existingMembership.length === 0) {
-        await db.insert(channelMembers).values({
-          channelId: generalChannel.id,
-          userEmail: user.email,
-        });
+      if (!alreadyMember) {
+        await insertChannelMember(db, generalChannel.id, user.email);
       }
     }
   } catch (error) {

--- a/hono/routes/messages.ts
+++ b/hono/routes/messages.ts
@@ -1,6 +1,7 @@
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { channelMembers, channels, getDb, messages } from "../db/index.js";
+import { getDb, messages } from "../db/index.js";
+import { getChannelInWorkspace, isChannelMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import type { Env } from "../types.js";
 
@@ -22,20 +23,14 @@ messagesRoute.get("/w/:slug/api/messages", async (c) => {
     const user = c.get("user");
     const workspace = getWorkspace(c);
 
-    const channel = await db
-      .select()
-      .from(channels)
-      .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)));
-    if (channel.length === 0) {
+    const channel = await getChannelInWorkspace(db, channelId, workspace.id);
+    if (!channel) {
       return c.json({ error: "Channel not found in this workspace" }, 404);
     }
 
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)));
+    const isMember = await isChannelMember(db, channelId, user.email);
 
-    if (membership.length === 0) {
+    if (!isMember) {
       return c.json({ error: "Not a member of this channel" }, 403);
     }
 

--- a/hono/routes/messages.ts
+++ b/hono/routes/messages.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { getDb, messages } from "../db/index.js";
 import { getChannelInWorkspace, isChannelMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
+import { parsePositiveInt } from "../helpers/parsePositiveInt.js";
 import type { Env } from "../types.js";
 
 const messagesRoute = new Hono<Env>();
@@ -14,8 +15,8 @@ messagesRoute.get("/w/:slug/api/messages", async (c) => {
       return c.json({ error: "channelId query parameter is required" }, 400);
     }
 
-    const channelId = Number(channelIdParam);
-    if (Number.isNaN(channelId)) {
+    const channelId = parsePositiveInt(channelIdParam);
+    if (!channelId) {
       return c.json({ error: "Invalid channelId" }, 400);
     }
 

--- a/hono/routes/uploads.test.ts
+++ b/hono/routes/uploads.test.ts
@@ -53,16 +53,12 @@ function setupWorkspaceMocks() {
 function setupChannelMocks() {
   mockSelect.mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue([{ id: 1, name: "general", workspaceId: 1 }]),
-      }),
+      where: vi.fn().mockResolvedValue([{ id: 1, name: "general", workspaceId: 1 }]),
     }),
   });
   mockSelect.mockReturnValueOnce({
     from: vi.fn().mockReturnValue({
-      where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue([{ id: 1, channelId: 1, userEmail: "test@example.com" }]),
-      }),
+      where: vi.fn().mockResolvedValue([{ id: 1, channelId: 1, userEmail: "test@example.com" }]),
     }),
   });
 }
@@ -196,16 +192,12 @@ describe("Upload API endpoint", () => {
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 1, name: "general", workspaceId: 1 }]),
-        }),
+        where: vi.fn().mockResolvedValue([{ id: 1, name: "general", workspaceId: 1 }]),
       }),
     });
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
+        where: vi.fn().mockResolvedValue([]),
       }),
     });
 
@@ -225,9 +217,7 @@ describe("Upload API endpoint", () => {
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
+        where: vi.fn().mockResolvedValue([]),
       }),
     });
 
@@ -273,9 +263,7 @@ describe("File serving endpoint", () => {
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([]),
-        }),
+        where: vi.fn().mockResolvedValue([]),
       }),
     });
 
@@ -290,9 +278,7 @@ describe("File serving endpoint", () => {
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 1, channelId: 1, userEmail: "test@example.com" }]),
-        }),
+        where: vi.fn().mockResolvedValue([{ id: 1, channelId: 1, userEmail: "test@example.com" }]),
       }),
     });
 
@@ -308,9 +294,7 @@ describe("File serving endpoint", () => {
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ id: 1, channelId: 1, userEmail: "test@example.com" }]),
-        }),
+        where: vi.fn().mockResolvedValue([{ id: 1, channelId: 1, userEmail: "test@example.com" }]),
       }),
     });
 

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { getDb } from "../db/index.js";
 import { getChannelInWorkspace, getConversationForParticipant, isChannelMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
+import { parsePositiveInt } from "../helpers/parsePositiveInt.js";
 import type { Env } from "../types.js";
 
 const MAX_FILE_SIZE = 25 * 1024 * 1024;
@@ -18,10 +19,6 @@ function getExtension(mimeType: string): string {
     "video/webm": "webm",
   };
   return map[mimeType] || "bin";
-}
-
-function isPositiveInteger(value: number): boolean {
-  return Number.isInteger(value) && value > 0;
 }
 
 const uploadsRoute = new Hono<Env>();
@@ -57,8 +54,8 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     let key: string;
 
     if (conversationIdParam) {
-      const conversationId = Number(conversationIdParam);
-      if (!isPositiveInteger(conversationId)) {
+      const conversationId = parsePositiveInt(conversationIdParam);
+      if (!conversationId) {
         return c.json({ error: "Invalid conversationId" }, 400);
       }
 
@@ -69,8 +66,8 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
 
       key = `${workspace.slug}/dm/${conversationId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
     } else {
-      const channelId = Number(channelIdParam);
-      if (!isPositiveInteger(channelId)) {
+      const channelId = parsePositiveInt(channelIdParam);
+      if (!channelId) {
         return c.json({ error: "Invalid channelId" }, 400);
       }
 
@@ -126,8 +123,8 @@ uploadsRoute.get("/w/:slug/api/files/*", async (c) => {
       if (keyParts.length < 4) {
         return c.json({ error: "File not found" }, 404);
       }
-      const conversationId = Number(keyParts[2]);
-      if (!isPositiveInteger(conversationId)) {
+      const conversationId = parsePositiveInt(keyParts[2]);
+      if (!conversationId) {
         return c.json({ error: "File not found" }, 404);
       }
 
@@ -136,8 +133,8 @@ uploadsRoute.get("/w/:slug/api/files/*", async (c) => {
         return c.json({ error: "File not found" }, 404);
       }
     } else {
-      const channelId = Number(keyParts[1]);
-      if (!isPositiveInteger(channelId)) {
+      const channelId = parsePositiveInt(keyParts[1]);
+      if (!channelId) {
         return c.json({ error: "File not found" }, 404);
       }
 

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -1,6 +1,6 @@
-import { and, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
-import { channelMembers, channels, directConversations, getDb } from "../db/index.js";
+import { getDb } from "../db/index.js";
+import { getChannelInWorkspace, getConversationForParticipant, isChannelMember } from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import type { Env } from "../types.js";
 
@@ -62,18 +62,8 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
         return c.json({ error: "Invalid conversationId" }, 400);
       }
 
-      const conversation = await db
-        .select()
-        .from(directConversations)
-        .where(
-          and(
-            eq(directConversations.id, conversationId),
-            eq(directConversations.workspaceId, workspace.id),
-            or(eq(directConversations.user1Email, user.email), eq(directConversations.user2Email, user.email)),
-          ),
-        )
-        .limit(1);
-      if (conversation.length === 0) {
+      const conversation = await getConversationForParticipant(db, conversationId, user.email, workspace.id);
+      if (!conversation) {
         return c.json({ error: "Conversation not found" }, 404);
       }
 
@@ -84,21 +74,13 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
         return c.json({ error: "Invalid channelId" }, 400);
       }
 
-      const channel = await db
-        .select()
-        .from(channels)
-        .where(and(eq(channels.id, channelId), eq(channels.workspaceId, workspace.id)))
-        .limit(1);
-      if (channel.length === 0) {
+      const channel = await getChannelInWorkspace(db, channelId, workspace.id);
+      if (!channel) {
         return c.json({ error: "Channel not found in this workspace" }, 404);
       }
 
-      const membership = await db
-        .select()
-        .from(channelMembers)
-        .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)))
-        .limit(1);
-      if (membership.length === 0) {
+      const isMember = await isChannelMember(db, channelId, user.email);
+      if (!isMember) {
         return c.json({ error: "Not a member of this channel" }, 403);
       }
 
@@ -149,18 +131,8 @@ uploadsRoute.get("/w/:slug/api/files/*", async (c) => {
         return c.json({ error: "File not found" }, 404);
       }
 
-      const conversation = await db
-        .select()
-        .from(directConversations)
-        .where(
-          and(
-            eq(directConversations.id, conversationId),
-            eq(directConversations.workspaceId, workspace.id),
-            or(eq(directConversations.user1Email, user.email), eq(directConversations.user2Email, user.email)),
-          ),
-        )
-        .limit(1);
-      if (conversation.length === 0) {
+      const conversation = await getConversationForParticipant(db, conversationId, user.email, workspace.id);
+      if (!conversation) {
         return c.json({ error: "File not found" }, 404);
       }
     } else {
@@ -169,12 +141,8 @@ uploadsRoute.get("/w/:slug/api/files/*", async (c) => {
         return c.json({ error: "File not found" }, 404);
       }
 
-      const membership = await db
-        .select()
-        .from(channelMembers)
-        .where(and(eq(channelMembers.channelId, channelId), eq(channelMembers.userEmail, user.email)))
-        .limit(1);
-      if (membership.length === 0) {
+      const isMember = await isChannelMember(db, channelId, user.email);
+      if (!isMember) {
         return c.json({ error: "File not found" }, 404);
       }
     }

--- a/hono/routes/workspaceInvite.ts
+++ b/hono/routes/workspaceInvite.ts
@@ -3,12 +3,7 @@ import { Hono } from "hono";
 import { requireUser } from "../auth/requireUser.js";
 import { InvitePage } from "../components/InvitePage.js";
 import { getDb, workspaceInvites, workspaceMembers, workspaces } from "../db/index.js";
-import {
-  getChannelByNameInWorkspace,
-  getWorkspaceMember,
-  insertChannelMember,
-  isChannelMember,
-} from "../db/queries/index.js";
+import { ensureGeneralChannelMembership, getWorkspaceMember } from "../db/queries/index.js";
 import { renderPage } from "../helpers/renderPage.js";
 import type { Env } from "../types.js";
 
@@ -86,15 +81,7 @@ workspaceInviteRoute.post("/w/:slug/invite/:code", requireUser, async (c) => {
         role: "member",
       });
 
-      const generalChannel = await getChannelByNameInWorkspace(db, workspace.id, "general");
-
-      if (generalChannel) {
-        const alreadyMember = await isChannelMember(db, generalChannel.id, user.email);
-
-        if (!alreadyMember) {
-          await insertChannelMember(db, generalChannel.id, user.email);
-        }
-      }
+      await ensureGeneralChannelMembership(db, workspace.id, user.email);
     }
 
     return c.redirect(`/w/${workspace.slug}`);

--- a/hono/routes/workspaceInvite.ts
+++ b/hono/routes/workspaceInvite.ts
@@ -2,7 +2,13 @@ import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { requireUser } from "../auth/requireUser.js";
 import { InvitePage } from "../components/InvitePage.js";
-import { channelMembers, channels, getDb, workspaceInvites, workspaceMembers, workspaces } from "../db/index.js";
+import { getDb, workspaceInvites, workspaceMembers, workspaces } from "../db/index.js";
+import {
+  getChannelByNameInWorkspace,
+  getWorkspaceMember,
+  insertChannelMember,
+  isChannelMember,
+} from "../db/queries/index.js";
 import { renderPage } from "../helpers/renderPage.js";
 import type { Env } from "../types.js";
 
@@ -33,10 +39,7 @@ workspaceInviteRoute.get("/w/:slug/invite/:code", requireUser, async (c) => {
       return renderPage(c, InvitePage({ error: "Invite link has expired" }), 410);
     }
 
-    const [existingMember] = await db
-      .select()
-      .from(workspaceMembers)
-      .where(and(eq(workspaceMembers.workspaceId, workspace.id), eq(workspaceMembers.userEmail, user.email)));
+    const existingMember = await getWorkspaceMember(db, workspace.id, user.email);
 
     if (existingMember) {
       return c.redirect(`/w/${workspace.slug}`);
@@ -74,10 +77,7 @@ workspaceInviteRoute.post("/w/:slug/invite/:code", requireUser, async (c) => {
       return c.json({ error: "Invite link has expired" }, 410);
     }
 
-    const [existingMember] = await db
-      .select()
-      .from(workspaceMembers)
-      .where(and(eq(workspaceMembers.workspaceId, workspace.id), eq(workspaceMembers.userEmail, user.email)));
+    const existingMember = await getWorkspaceMember(db, workspace.id, user.email);
 
     if (!existingMember) {
       await db.insert(workspaceMembers).values({
@@ -86,22 +86,13 @@ workspaceInviteRoute.post("/w/:slug/invite/:code", requireUser, async (c) => {
         role: "member",
       });
 
-      const [generalChannel] = await db
-        .select()
-        .from(channels)
-        .where(and(eq(channels.workspaceId, workspace.id), eq(channels.name, "general")));
+      const generalChannel = await getChannelByNameInWorkspace(db, workspace.id, "general");
 
       if (generalChannel) {
-        const [existingChannelMember] = await db
-          .select()
-          .from(channelMembers)
-          .where(and(eq(channelMembers.channelId, generalChannel.id), eq(channelMembers.userEmail, user.email)));
+        const alreadyMember = await isChannelMember(db, generalChannel.id, user.email);
 
-        if (!existingChannelMember) {
-          await db.insert(channelMembers).values({
-            channelId: generalChannel.id,
-            userEmail: user.email,
-          });
+        if (!alreadyMember) {
+          await insertChannelMember(db, generalChannel.id, user.email);
         }
       }
     }


### PR DESCRIPTION
## Summary

Architecture refactoring that reduces duplication across the codebase in three areas:

### 1. Shared Layout Component
- Created `Layout.tsx` — a shared HTML shell replacing ~140 lines of duplicated `<html>/<head>/<body>` boilerplate across all 7 page components
- Props: `title`, `css`, `scripts`, `viewportFit`, `children`

### 2. CSS Deduplication
- Extracted `common.css` with shared base reset, body font, and modal structural rules
- Trimmed duplicated rules from `ChatPage.css`, `WorkspacesPage.css`, `AuthPage.css`, and `AboutPage.css`
- Theme-specific colors (dark/light) remain in their respective page CSS files

### 3. Data Access Layer (DAL)
- Created `hono/db/queries/` with 5 reusable query functions replacing 20+ duplicated inline DB queries:
  - `isChannelMember`, `getChannelInWorkspace`, `getChannelByNameInWorkspace`, `insertChannelMember`, `getChannelMemberEmails`
  - `getConversationForParticipant` (with optional `workspaceId`)
  - `getUserNameByEmail`, `getUsersByEmails`
  - `getWorkspaceMember`
- Made `insertChannelMember` idempotent with `onConflictDoNothing()` (fixes a race condition)
- Updated 7 consumer files to use DAL functions, removing direct drizzle-orm imports where possible

### Stats
- **Existing files:** −570 lines removed, +312 lines added (net −258)
- **New production code:** +210 lines
- **New tests:** +321 lines (18 tests for Layout + DAL modules)
- **Net production code: −48 lines**

### Testing
- All 208 tests pass
- Lint clean, build succeeds
- Copilot CLI reviews run on all changed files