### PR TITLE
feat(uploads): enforce 10 GB per-user upload quota

### DIFF
--- a/hono/db/migrations/0005_add_user_email_indexes.sql
+++ b/hono/db/migrations/0005_add_user_email_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `messages_user_email_idx` ON `messages` (`user_email`);--> statement-breakpoint
+CREATE INDEX `direct_messages_user_email_idx` ON `direct_messages` (`user_email`);

--- a/hono/db/migrations/meta/0005_snapshot.json
+++ b/hono/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,790 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0005_add_user_email_indexes",
+  "prevId": "8a99a884-6ca5-4a76-90dc-7e002867df1b",
+  "tables": {
+    "channel_members": {
+      "name": "channel_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "channel_members_channel_id_user_email_unique": {
+          "name": "channel_members_channel_id_user_email_unique",
+          "columns": [
+            "channel_id",
+            "user_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_members_channel_id_channels_id_fk": {
+          "name": "channel_members_channel_id_channels_id_fk",
+          "tableFrom": "channel_members",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "channels_workspace_id_name_unique": {
+          "name": "channels_workspace_id_name_unique",
+          "columns": [
+            "workspace_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channels_workspace_id_workspaces_id_fk": {
+          "name": "channels_workspace_id_workspaces_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "direct_conversations": {
+      "name": "direct_conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user1_email": {
+          "name": "user1_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user2_email": {
+          "name": "user2_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "direct_conversations_workspace_users_unique": {
+          "name": "direct_conversations_workspace_users_unique",
+          "columns": [
+            "workspace_id",
+            "user1_email",
+            "user2_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "direct_conversations_workspace_id_workspaces_id_fk": {
+          "name": "direct_conversations_workspace_id_workspaces_id_fk",
+          "tableFrom": "direct_conversations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "direct_messages": {
+      "name": "direct_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachment_key": {
+          "name": "attachment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_name": {
+          "name": "attachment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_size": {
+          "name": "attachment_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "direct_messages_conversation_id_created_at_idx": {
+          "name": "direct_messages_conversation_id_created_at_idx",
+          "columns": [
+            "conversation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "direct_messages_user_email_idx": {
+          "name": "direct_messages_user_email_idx",
+          "columns": [
+            "user_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversation_id_direct_conversations_id_fk": {
+          "name": "direct_messages_conversation_id_direct_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachment_key": {
+          "name": "attachment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_name": {
+          "name": "attachment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_type": {
+          "name": "attachment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attachment_size": {
+          "name": "attachment_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "messages_created_at_idx": {
+          "name": "messages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "messages_channel_id_created_at_idx": {
+          "name": "messages_channel_id_created_at_idx",
+          "columns": [
+            "channel_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "messages_user_email_idx": {
+          "name": "messages_user_email_idx",
+          "columns": [
+            "user_email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_channel_id_channels_id_fk": {
+          "name": "messages_channel_id_channels_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_registrations": {
+      "name": "pending_registrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_code": {
+          "name": "verification_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "pending_registrations_email_unique": {
+          "name": "pending_registrations_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "pending_registrations_expires_at_index": {
+          "name": "pending_registrations_expires_at_index",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_invites": {
+      "name": "workspace_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "workspace_invites_code_unique": {
+          "name": "workspace_invites_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "workspace_invites_expires_at_idx": {
+          "name": "workspace_invites_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_invites_workspace_id_workspaces_id_fk": {
+          "name": "workspace_invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_invites",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_members": {
+      "name": "workspace_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "workspace_members_workspace_id_user_email_unique": {
+          "name": "workspace_members_workspace_id_user_email_unique",
+          "columns": [
+            "workspace_id",
+            "user_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "workspace_members_workspace_id_workspaces_id_fk": {
+          "name": "workspace_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_email": {
+          "name": "created_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/hono/db/migrations/meta/_journal.json
+++ b/hono/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775736732300,
       "tag": "0004_messy_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1776060614536,
+      "tag": "0005_add_user_email_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/hono/db/queries/index.ts
+++ b/hono/db/queries/index.ts
@@ -8,5 +8,6 @@ export {
 } from "./channel.js";
 export { getConversationForParticipant } from "./conversation.js";
 export type { Database } from "./types.js";
+export { getUserTotalUploadSize } from "./upload.js";
 export { getUserNameByEmail, getUsersByEmails } from "./user.js";
 export { getWorkspaceMember } from "./workspace.js";

--- a/hono/db/queries/upload.test.ts
+++ b/hono/db/queries/upload.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserTotalUploadSize } from "./upload.js";
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockDb = {
+  select: vi.fn().mockReturnValue({ from: mockFrom }),
+} as never;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockDb.select.mockReturnValue({ from: mockFrom });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReset();
+});
+
+describe("getUserTotalUploadSize", () => {
+  it("should return 0 when user has no attachments", async () => {
+    mockWhere.mockResolvedValueOnce([{ total: 0 }]);
+    mockWhere.mockResolvedValueOnce([{ total: 0 }]);
+
+    const result = await getUserTotalUploadSize(mockDb, "user@example.com");
+
+    expect(result).toBe(0);
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
+  });
+
+  it("should sum attachment sizes from both messages and direct messages", async () => {
+    mockWhere.mockResolvedValueOnce([{ total: 5000 }]);
+    mockWhere.mockResolvedValueOnce([{ total: 3000 }]);
+
+    const result = await getUserTotalUploadSize(mockDb, "user@example.com");
+
+    expect(result).toBe(8000);
+  });
+
+  it("should handle null totals gracefully", async () => {
+    mockWhere.mockResolvedValueOnce([{ total: null }]);
+    mockWhere.mockResolvedValueOnce([{ total: null }]);
+
+    const result = await getUserTotalUploadSize(mockDb, "user@example.com");
+
+    expect(result).toBe(0);
+  });
+
+  it("should handle missing result rows", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+    mockWhere.mockResolvedValueOnce([]);
+
+    const result = await getUserTotalUploadSize(mockDb, "user@example.com");
+
+    expect(result).toBe(0);
+  });
+
+  it("should propagate database errors", async () => {
+    mockWhere.mockResolvedValueOnce([{ total: 1000 }]);
+    mockWhere.mockRejectedValueOnce(new Error("DB connection failed"));
+
+    await expect(getUserTotalUploadSize(mockDb, "user@example.com")).rejects.toThrow("DB connection failed");
+  });
+});

--- a/hono/db/queries/upload.ts
+++ b/hono/db/queries/upload.ts
@@ -1,0 +1,18 @@
+import { eq, sql } from "drizzle-orm";
+import { directMessages, messages } from "../schema.js";
+import type { Database } from "./types.js";
+
+export async function getUserTotalUploadSize(db: Database, userEmail: string): Promise<number> {
+  const [channelResult, dmResult] = await Promise.all([
+    db
+      .select({ total: sql<number>`COALESCE(SUM(${messages.attachmentSize}), 0)` })
+      .from(messages)
+      .where(eq(messages.userEmail, userEmail)),
+    db
+      .select({ total: sql<number>`COALESCE(SUM(${directMessages.attachmentSize}), 0)` })
+      .from(directMessages)
+      .where(eq(directMessages.userEmail, userEmail)),
+  ]);
+
+  return (channelResult[0]?.total ?? 0) + (dmResult[0]?.total ?? 0);
+}

--- a/hono/db/schema.ts
+++ b/hono/db/schema.ts
@@ -84,6 +84,7 @@ export const messages = sqliteTable(
   (table) => [
     index("messages_created_at_idx").on(table.createdAt),
     index("messages_channel_id_created_at_idx").on(table.channelId, table.createdAt),
+    index("messages_user_email_idx").on(table.userEmail),
   ],
 );
 
@@ -126,6 +127,7 @@ export const directMessages = sqliteTable(
   (table) => [
     index("direct_messages_created_at_idx").on(table.createdAt),
     index("direct_messages_conversation_id_created_at_idx").on(table.conversationId, table.createdAt),
+    index("direct_messages_user_email_idx").on(table.userEmail),
   ],
 );
 

--- a/hono/routes/uploads.test.ts
+++ b/hono/routes/uploads.test.ts
@@ -63,6 +63,19 @@ function setupChannelMocks() {
   });
 }
 
+function setupQuotaMocks(channelUsageBytes = 0, dmUsageBytes = 0) {
+  mockSelect.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([{ total: channelUsageBytes }]),
+    }),
+  });
+  mockSelect.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([{ total: dmUsageBytes }]),
+    }),
+  });
+}
+
 function createTestFile(name: string, type: string, sizeBytes: number): File {
   const buffer = new ArrayBuffer(sizeBytes);
   return new File([buffer], name, { type });
@@ -82,6 +95,7 @@ function createUploadRequest(file: File, channelId: string): Request {
 describe("Upload API endpoint", () => {
   it("should upload a valid image file", async () => {
     setupWorkspaceMocks();
+    setupQuotaMocks();
     setupChannelMocks();
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
@@ -189,6 +203,7 @@ describe("Upload API endpoint", () => {
 
   it("should return 403 when user is not a channel member", async () => {
     setupWorkspaceMocks();
+    setupQuotaMocks();
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
@@ -214,6 +229,7 @@ describe("Upload API endpoint", () => {
 
   it("should return 404 when channel does not exist", async () => {
     setupWorkspaceMocks();
+    setupQuotaMocks();
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
@@ -239,6 +255,7 @@ describe("Upload API endpoint", () => {
     for (const invalidId of ["0", "-1", "1.5", "abc"]) {
       mockSelect.mockReset();
       setupWorkspaceMocks();
+      setupQuotaMocks();
       const file = createTestFile("photo.jpg", "image/jpeg", 1024);
       const request = createUploadRequest(file, invalidId);
       const response = await app.request(request);
@@ -247,6 +264,68 @@ describe("Upload API endpoint", () => {
       const body = (await response.json()) as { error: string };
       expect(body.error).toBe("Invalid channelId");
     }
+  });
+
+  it("should return 413 when upload would exceed storage quota", async () => {
+    setupWorkspaceMocks();
+    const almostFullUsage = 10 * 1024 * 1024 * 1024 - 512;
+    setupQuotaMocks(almostFullUsage, 0);
+
+    const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
+    const file = createTestFile("photo.jpg", "image/jpeg", 1024);
+    const request = createUploadRequest(file, "1");
+    const response = await app.request(request);
+    expect(response.status).toBe(413);
+
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("Storage quota exceeded");
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("should allow upload when under storage quota", async () => {
+    setupWorkspaceMocks();
+    setupQuotaMocks(5 * 1024 * 1024 * 1024, 0);
+    setupChannelMocks();
+
+    mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
+
+    const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
+    const file = createTestFile("photo.jpg", "image/jpeg", 1024);
+    const request = createUploadRequest(file, "1");
+    const response = await app.request(request);
+    expect(response.status).toBe(200);
+    expect(mockPut).toHaveBeenCalledOnce();
+  });
+
+  it("should allow upload when usage is exactly at boundary", async () => {
+    setupWorkspaceMocks();
+    const maxMinusFileSize = 10 * 1024 * 1024 * 1024 - 1024;
+    setupQuotaMocks(maxMinusFileSize, 0);
+    setupChannelMocks();
+
+    mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
+
+    const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
+    const file = createTestFile("photo.jpg", "image/jpeg", 1024);
+    const request = createUploadRequest(file, "1");
+    const response = await app.request(request);
+    expect(response.status).toBe(200);
+    expect(mockPut).toHaveBeenCalledOnce();
+  });
+
+  it("should account for both channel and DM usage in quota", async () => {
+    setupWorkspaceMocks();
+    setupQuotaMocks(6 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024);
+
+    const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
+    const file = createTestFile("photo.jpg", "image/jpeg", 1024);
+    const request = createUploadRequest(file, "1");
+    const response = await app.request(request);
+    expect(response.status).toBe(413);
+
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("Storage quota exceeded");
+    expect(mockPut).not.toHaveBeenCalled();
   });
 });
 

--- a/hono/routes/uploads.test.ts
+++ b/hono/routes/uploads.test.ts
@@ -95,8 +95,8 @@ function createUploadRequest(file: File, channelId: string): Request {
 describe("Upload API endpoint", () => {
   it("should upload a valid image file", async () => {
     setupWorkspaceMocks();
-    setupQuotaMocks();
     setupChannelMocks();
+    setupQuotaMocks();
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
 
@@ -203,7 +203,6 @@ describe("Upload API endpoint", () => {
 
   it("should return 403 when user is not a channel member", async () => {
     setupWorkspaceMocks();
-    setupQuotaMocks();
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
@@ -229,7 +228,6 @@ describe("Upload API endpoint", () => {
 
   it("should return 404 when channel does not exist", async () => {
     setupWorkspaceMocks();
-    setupQuotaMocks();
 
     mockSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
@@ -255,7 +253,6 @@ describe("Upload API endpoint", () => {
     for (const invalidId of ["0", "-1", "1.5", "abc"]) {
       mockSelect.mockReset();
       setupWorkspaceMocks();
-      setupQuotaMocks();
       const file = createTestFile("photo.jpg", "image/jpeg", 1024);
       const request = createUploadRequest(file, invalidId);
       const response = await app.request(request);
@@ -268,6 +265,7 @@ describe("Upload API endpoint", () => {
 
   it("should return 413 when upload would exceed storage quota", async () => {
     setupWorkspaceMocks();
+    setupChannelMocks();
     const almostFullUsage = 10 * 1024 * 1024 * 1024 - 512;
     setupQuotaMocks(almostFullUsage, 0);
 
@@ -284,8 +282,8 @@ describe("Upload API endpoint", () => {
 
   it("should allow upload when under storage quota", async () => {
     setupWorkspaceMocks();
-    setupQuotaMocks(5 * 1024 * 1024 * 1024, 0);
     setupChannelMocks();
+    setupQuotaMocks(5 * 1024 * 1024 * 1024, 0);
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
 
@@ -299,9 +297,9 @@ describe("Upload API endpoint", () => {
 
   it("should allow upload when usage is exactly at boundary", async () => {
     setupWorkspaceMocks();
+    setupChannelMocks();
     const maxMinusFileSize = 10 * 1024 * 1024 * 1024 - 1024;
     setupQuotaMocks(maxMinusFileSize, 0);
-    setupChannelMocks();
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
 
@@ -315,6 +313,7 @@ describe("Upload API endpoint", () => {
 
   it("should account for both channel and DM usage in quota", async () => {
     setupWorkspaceMocks();
+    setupChannelMocks();
     setupQuotaMocks(6 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024);
 
     const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -1,11 +1,18 @@
 import { Hono } from "hono";
 import { getDb } from "../db/index.js";
-import { getChannelInWorkspace, getConversationForParticipant, isChannelMember } from "../db/queries/index.js";
+import {
+  getChannelInWorkspace,
+  getConversationForParticipant,
+  getUserTotalUploadSize,
+  isChannelMember,
+} from "../db/queries/index.js";
 import { getWorkspace } from "../helpers/getWorkspace.js";
 import { parsePositiveInt } from "../helpers/parsePositiveInt.js";
 import type { Env } from "../types.js";
 
 const MAX_FILE_SIZE = 25 * 1024 * 1024;
+
+const MAX_TOTAL_UPLOAD_SIZE = 10 * 1024 * 1024 * 1024;
 
 const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp", "video/mp4", "video/webm"]);
 
@@ -50,6 +57,12 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     }
 
     const db = getDb(c.env.DB);
+
+    const currentUsage = await getUserTotalUploadSize(db, user.email);
+    if (currentUsage + file.size > MAX_TOTAL_UPLOAD_SIZE) {
+      return c.json({ error: "Storage quota exceeded. Maximum total upload size is 10 GB" }, 413);
+    }
+
     const ext = getExtension(file.type);
     let key: string;
 

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -57,12 +57,6 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     }
 
     const db = getDb(c.env.DB);
-
-    const currentUsage = await getUserTotalUploadSize(db, user.email);
-    if (currentUsage + file.size > MAX_TOTAL_UPLOAD_SIZE) {
-      return c.json({ error: "Storage quota exceeded. Maximum total upload size is 10 GB" }, 413);
-    }
-
     const ext = getExtension(file.type);
     let key: string;
 
@@ -95,6 +89,11 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
       }
 
       key = `${workspace.slug}/${channelId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+    }
+
+    const currentUsage = await getUserTotalUploadSize(db, user.email);
+    if (currentUsage + file.size > MAX_TOTAL_UPLOAD_SIZE) {
+      return c.json({ error: "Storage quota exceeded. Maximum total upload size is 10 GB" }, 413);
     }
 
     await c.env.STORAGE.put(key, file.stream(), {


### PR DESCRIPTION
## Summary

Adds per-user storage quota enforcement to prevent any single user from uploading more than **10 GB** of files.

## How it works

Before storing a file to R2, the upload route computes the user's total upload usage by summing `attachmentSize` from both `messages` and `directMessages` tables. If the new file would push the user over the 10 GB cap, the request is rejected with a **413** response.

## Changes

| File | Change |
|---|---|
| `hono/db/queries/upload.ts` | New `getUserTotalUploadSize` query — runs two SUM queries in parallel via `Promise.all()` |
| `hono/db/queries/index.ts` | Export the new query |
| `hono/routes/uploads.ts` | `MAX_TOTAL_UPLOAD_SIZE` constant + quota check before R2 put |
| `hono/db/schema.ts` | `user_email` indexes on `messages` and `direct_messages` for query performance |
| `hono/db/migrations/0005_add_user_email_indexes.sql` | Migration for the new indexes |
| `hono/db/queries/upload.test.ts` | 5 unit tests for the query (zero usage, sum, null handling, missing rows, error propagation) |
| `hono/routes/uploads.test.ts` | 4 new tests for quota enforcement (exceeded, under quota, boundary, combined channel+DM usage) |

## Testing

- All **226 unit tests** pass
- Lint clean, build succeeds