### PR TITLE
feat(admin): add site admin view with per-user feature flags

### DIFF
--- a/hono/app.tsx
+++ b/hono/app.tsx
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { csrf } from "hono/csrf";
 import type { MiddlewareHandler } from "hono/types";
 import { CookieStore, sessionMiddleware } from "hono-sessions";
+import { requireSiteAdmin } from "./auth/requireSiteAdmin.js";
 import { requireWorkspaceMember } from "./auth/requireWorkspaceMember.js";
 import { authRoute } from "./routes/auth.js";
 import { channelsRoute } from "./routes/channels.js";
@@ -10,6 +11,7 @@ import { emailAuthRoute } from "./routes/emailAuth.js";
 import { healthRoute } from "./routes/health.js";
 import { indexRoute } from "./routes/index.js";
 import { messagesRoute } from "./routes/messages.js";
+import { siteAdminRoute } from "./routes/siteAdmin.js";
 import { testAuthRoute } from "./routes/testAuth.js";
 import { uploadsRoute } from "./routes/uploads.js";
 import { workspaceAdminRoute } from "./routes/workspaceAdmin.js";
@@ -65,6 +67,10 @@ export function createApp(options?: AppOptions) {
 
   app.route("/", workspacesRoute);
   app.route("/", workspaceInviteRoute);
+
+  app.use("/site-admin/*", requireSiteAdmin);
+  app.use("/site-admin", requireSiteAdmin);
+  app.route("/", siteAdminRoute);
 
   app.use("/w/:slug/api/*", requireWorkspaceMember);
   app.use("/w/:slug/admin/*", requireWorkspaceMember);

--- a/hono/auth/requireSiteAdmin.test.ts
+++ b/hono/auth/requireSiteAdmin.test.ts
@@ -1,0 +1,73 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { Env } from "../types.js";
+import { requireSiteAdmin } from "./requireSiteAdmin.js";
+
+function createTestApp(options: { userEmail?: string; siteAdminEmail?: string }) {
+  const app = new Hono<Env>();
+
+  app.use("*", async (c, next) => {
+    const mockSession = {
+      get: vi.fn().mockReturnValue(options.userEmail ? { email: options.userEmail, name: "Test User" } : null),
+      set: vi.fn(),
+      deleteSession: vi.fn(),
+    };
+    c.set("session", mockSession as never);
+
+    if (!c.env) {
+      (c as never as Record<string, unknown>).env = {};
+    }
+    c.env.SITE_ADMIN_EMAIL = options.siteAdminEmail ?? "";
+    await next();
+  });
+
+  app.use("*", requireSiteAdmin);
+  app.get("/site-admin", (c) => c.json({ ok: true }));
+
+  return app;
+}
+
+describe("requireSiteAdmin", () => {
+  it("should return 401 when no user is logged in", async () => {
+    const app = createTestApp({ siteAdminEmail: "admin@example.com" });
+    const response = await app.request("/site-admin");
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("should return 403 when user is not the site admin", async () => {
+    const app = createTestApp({
+      userEmail: "user@example.com",
+      siteAdminEmail: "admin@example.com",
+    });
+    const response = await app.request("/site-admin");
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toEqual({ error: "Site admin access required" });
+  });
+
+  it("should return 403 when SITE_ADMIN_EMAIL is not configured", async () => {
+    const app = createTestApp({
+      userEmail: "user@example.com",
+      siteAdminEmail: "",
+    });
+    const response = await app.request("/site-admin");
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should allow the site admin through", async () => {
+    const app = createTestApp({
+      userEmail: "admin@example.com",
+      siteAdminEmail: "admin@example.com",
+    });
+    const response = await app.request("/site-admin");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ ok: true });
+  });
+});

--- a/hono/auth/requireSiteAdmin.ts
+++ b/hono/auth/requireSiteAdmin.ts
@@ -1,0 +1,24 @@
+import { createMiddleware } from "hono/factory";
+import type { Env, User } from "../types.js";
+
+export const requireSiteAdmin = createMiddleware<Env>(async (c, next) => {
+  const session = c.get("session");
+  const user = session.get("user") as User | undefined;
+
+  if (!user) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const siteAdminEmail = c.env.SITE_ADMIN_EMAIL;
+  if (!siteAdminEmail) {
+    console.error("SITE_ADMIN_EMAIL is not configured");
+    return c.json({ error: "Site admin access required" }, 403);
+  }
+
+  if (user.email.trim().toLowerCase() !== siteAdminEmail.trim().toLowerCase()) {
+    return c.json({ error: "Site admin access required" }, 403);
+  }
+
+  c.set("user", user);
+  await next();
+});

--- a/hono/components/SiteAdminPage.css
+++ b/hono/components/SiteAdminPage.css
@@ -1,0 +1,155 @@
+.site-admin-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.site-admin-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 1rem;
+}
+
+.site-admin-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #1a202c;
+}
+
+.admin-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.admin-email {
+  color: #718096;
+  font-size: 0.875rem;
+}
+
+.back-link {
+  color: #4a90d9;
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.users-section h2 {
+  font-size: 1.25rem;
+  color: #2d3748;
+  margin-bottom: 1rem;
+}
+
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.users-table th,
+.users-table td {
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.users-table th {
+  background: #f7fafc;
+  font-weight: 600;
+  color: #4a5568;
+  font-size: 0.875rem;
+}
+
+.user-email-cell {
+  font-family: monospace;
+  font-size: 0.875rem;
+}
+
+.no-flags {
+  color: #a0aec0;
+  font-style: italic;
+}
+
+.flag-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.flag-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.flag-key {
+  background: #edf2f7;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: #4a5568;
+}
+
+.flag-value {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: #2d3748;
+}
+
+.remove-flag-button {
+  background: none;
+  border: 1px solid #e53e3e;
+  color: #e53e3e;
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.75rem;
+}
+
+.remove-flag-button:hover {
+  background: #fff5f5;
+}
+
+.flag-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.flag-key-select,
+.flag-value-input {
+  padding: 0.375rem;
+  border: 1px solid #cbd5e0;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.flag-value-input {
+  width: 140px;
+}
+
+.set-flag-button {
+  background: #4a90d9;
+  color: #fff;
+  border: none;
+  padding: 0.375rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.set-flag-button:hover {
+  background: #3182ce;
+}
+
+.empty-state {
+  color: #a0aec0;
+  font-style: italic;
+}

--- a/hono/components/SiteAdminPage.tsx
+++ b/hono/components/SiteAdminPage.tsx
@@ -1,0 +1,91 @@
+import type { User } from "../types.js";
+import { Layout } from "./Layout.js";
+
+type UserWithFlags = {
+  email: string;
+  name: string;
+  flags: Array<{ flagKey: string; flagValue: string; grantedBy: string; createdAt: string | null }>;
+};
+
+export async function SiteAdminPage(admin: User, usersWithFlags: UserWithFlags[]) {
+  return (
+    <Layout title="Site Admin" css="/components/SiteAdminPage.css" scripts={["/static/siteAdmin.js"]}>
+      <div className="site-admin-container">
+        <div className="site-admin-header">
+          <h1>Site Admin</h1>
+          <div className="admin-info">
+            <span className="admin-email">{admin.email}</span>
+            <a href="/" className="back-link">
+              Back to Mlack
+            </a>
+          </div>
+        </div>
+
+        <section className="users-section">
+          <h2>Users</h2>
+          {usersWithFlags.length === 0 ? (
+            <p className="empty-state">No registered users.</p>
+          ) : (
+            <table className="users-table">
+              <thead>
+                <tr>
+                  <th>Email</th>
+                  <th>Name</th>
+                  <th>Feature Flags</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usersWithFlags.map((u) => (
+                  <tr className="user-row" data-email={u.email}>
+                    <td className="user-email-cell">{u.email}</td>
+                    <td>{u.name}</td>
+                    <td>
+                      {u.flags.length === 0 ? (
+                        <span className="no-flags">None</span>
+                      ) : (
+                        <ul className="flag-list">
+                          {u.flags.map((f) => (
+                            <li className="flag-item">
+                              <span className="flag-key">{f.flagKey}</span>
+                              <span className="flag-value">{f.flagValue}</span>
+                              <button
+                                type="button"
+                                className="remove-flag-button"
+                                data-email={u.email}
+                                data-flag-key={f.flagKey}
+                              >
+                                Remove
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                    <td>
+                      <div className="flag-form">
+                        <select className="flag-key-select">
+                          <option value="maxTotalUploadBytes">Max Upload (bytes)</option>
+                        </select>
+                        <input
+                          type="number"
+                          className="flag-value-input"
+                          placeholder="e.g. 21474836480"
+                          min="1"
+                          step="1"
+                        />
+                        <button type="button" className="set-flag-button" data-email={u.email}>
+                          Set Flag
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      </div>
+    </Layout>
+  );
+}

--- a/hono/db/migrations/0006_add_user_feature_flags.sql
+++ b/hono/db/migrations/0006_add_user_feature_flags.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `user_feature_flags` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_email` text NOT NULL,
+	`flag_key` text NOT NULL,
+	`flag_value` text NOT NULL,
+	`granted_by` text NOT NULL,
+	`created_at` text DEFAULT (CURRENT_TIMESTAMP)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_feature_flags_email_key_unique` ON `user_feature_flags` (`user_email`,`flag_key`);

--- a/hono/db/migrations/meta/_journal.json
+++ b/hono/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776060614536,
       "tag": "0005_add_user_email_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1776200000000,
+      "tag": "0006_add_user_feature_flags",
+      "breakpoints": true
     }
   ]
 }

--- a/hono/db/queries/index.ts
+++ b/hono/db/queries/index.ts
@@ -10,4 +10,11 @@ export { getConversationForParticipant } from "./conversation.js";
 export type { Database } from "./types.js";
 export { getUserTotalUploadSize } from "./upload.js";
 export { getUserNameByEmail, getUsersByEmails } from "./user.js";
+export {
+  deleteUserFeatureFlag,
+  getAllFeatureFlagsGroupedByUser,
+  getUserFeatureFlag,
+  getUserFeatureFlags,
+  setUserFeatureFlag,
+} from "./userFeatureFlags.js";
 export { getWorkspaceMember } from "./workspace.js";

--- a/hono/db/queries/userFeatureFlags.test.ts
+++ b/hono/db/queries/userFeatureFlags.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteUserFeatureFlag,
+  getUserFeatureFlag,
+  getUserFeatureFlags,
+  setUserFeatureFlag,
+} from "./userFeatureFlags.js";
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockValues = vi.fn();
+const mockOnConflictDoUpdate = vi.fn();
+const mockDelete = vi.fn();
+const mockReturning = vi.fn();
+
+const mockDb = {
+  select: vi.fn().mockReturnValue({ from: mockFrom }),
+  insert: vi.fn().mockReturnValue({ values: mockValues }),
+  delete: vi.fn().mockReturnValue({ where: mockWhere }),
+} as never;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockDb.select.mockReturnValue({ from: mockFrom });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReset();
+
+  mockDb.insert.mockReturnValue({ values: mockValues });
+  mockValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
+  mockOnConflictDoUpdate.mockResolvedValue(undefined);
+
+  mockDb.delete.mockReturnValue({ where: mockDelete });
+  mockDelete.mockReturnValue({ returning: mockReturning });
+  mockReturning.mockResolvedValue([]);
+});
+
+describe("getUserFeatureFlag", () => {
+  it("should return the flag value when it exists", async () => {
+    mockWhere.mockResolvedValueOnce([{ flagValue: "21474836480" }]);
+
+    const result = await getUserFeatureFlag(mockDb, "user@example.com", "maxTotalUploadBytes");
+
+    expect(result).toBe("21474836480");
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return null when the flag does not exist", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    const result = await getUserFeatureFlag(mockDb, "user@example.com", "maxTotalUploadBytes");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getUserFeatureFlags", () => {
+  it("should return all flags for a user", async () => {
+    const flags = [
+      {
+        flagKey: "maxTotalUploadBytes",
+        flagValue: "21474836480",
+        grantedBy: "admin@example.com",
+        createdAt: "2026-01-01",
+      },
+    ];
+    mockWhere.mockResolvedValueOnce(flags);
+
+    const result = await getUserFeatureFlags(mockDb, "user@example.com");
+
+    expect(result).toEqual(flags);
+  });
+
+  it("should return empty array when user has no flags", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+
+    const result = await getUserFeatureFlags(mockDb, "user@example.com");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("setUserFeatureFlag", () => {
+  it("should insert or update a flag", async () => {
+    await setUserFeatureFlag(mockDb, "user@example.com", "maxTotalUploadBytes", "21474836480", "admin@example.com");
+
+    expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    expect(mockValues).toHaveBeenCalledWith({
+      userEmail: "user@example.com",
+      flagKey: "maxTotalUploadBytes",
+      flagValue: "21474836480",
+      grantedBy: "admin@example.com",
+    });
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deleteUserFeatureFlag", () => {
+  it("should return true when a flag was deleted", async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 1 }]);
+
+    const result = await deleteUserFeatureFlag(mockDb, "user@example.com", "maxTotalUploadBytes");
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false when the flag did not exist", async () => {
+    mockReturning.mockResolvedValueOnce([]);
+
+    const result = await deleteUserFeatureFlag(mockDb, "user@example.com", "maxTotalUploadBytes");
+
+    expect(result).toBe(false);
+  });
+});

--- a/hono/db/queries/userFeatureFlags.ts
+++ b/hono/db/queries/userFeatureFlags.ts
@@ -1,0 +1,74 @@
+import { and, eq } from "drizzle-orm";
+import { userFeatureFlags } from "../schema.js";
+import type { Database } from "./types.js";
+
+type FeatureFlag = { flagKey: string; flagValue: string; grantedBy: string; createdAt: string | null };
+
+export async function getUserFeatureFlag(db: Database, userEmail: string, flagKey: string): Promise<string | null> {
+  const [row] = await db
+    .select({ flagValue: userFeatureFlags.flagValue })
+    .from(userFeatureFlags)
+    .where(and(eq(userFeatureFlags.userEmail, userEmail), eq(userFeatureFlags.flagKey, flagKey)));
+  return row?.flagValue ?? null;
+}
+
+export async function getUserFeatureFlags(db: Database, userEmail: string): Promise<FeatureFlag[]> {
+  return db
+    .select({
+      flagKey: userFeatureFlags.flagKey,
+      flagValue: userFeatureFlags.flagValue,
+      grantedBy: userFeatureFlags.grantedBy,
+      createdAt: userFeatureFlags.createdAt,
+    })
+    .from(userFeatureFlags)
+    .where(eq(userFeatureFlags.userEmail, userEmail));
+}
+
+export async function getAllFeatureFlagsGroupedByUser(db: Database): Promise<Map<string, FeatureFlag[]>> {
+  const rows = await db
+    .select({
+      userEmail: userFeatureFlags.userEmail,
+      flagKey: userFeatureFlags.flagKey,
+      flagValue: userFeatureFlags.flagValue,
+      grantedBy: userFeatureFlags.grantedBy,
+      createdAt: userFeatureFlags.createdAt,
+    })
+    .from(userFeatureFlags);
+
+  const grouped = new Map<string, FeatureFlag[]>();
+  for (const row of rows) {
+    const existing = grouped.get(row.userEmail) ?? [];
+    existing.push({
+      flagKey: row.flagKey,
+      flagValue: row.flagValue,
+      grantedBy: row.grantedBy,
+      createdAt: row.createdAt,
+    });
+    grouped.set(row.userEmail, existing);
+  }
+  return grouped;
+}
+
+export async function setUserFeatureFlag(
+  db: Database,
+  userEmail: string,
+  flagKey: string,
+  flagValue: string,
+  grantedBy: string,
+): Promise<void> {
+  await db
+    .insert(userFeatureFlags)
+    .values({ userEmail, flagKey, flagValue, grantedBy })
+    .onConflictDoUpdate({
+      target: [userFeatureFlags.userEmail, userFeatureFlags.flagKey],
+      set: { flagValue, grantedBy },
+    });
+}
+
+export async function deleteUserFeatureFlag(db: Database, userEmail: string, flagKey: string): Promise<boolean> {
+  const deleted = await db
+    .delete(userFeatureFlags)
+    .where(and(eq(userFeatureFlags.userEmail, userEmail), eq(userFeatureFlags.flagKey, flagKey)))
+    .returning();
+  return deleted.length > 0;
+}

--- a/hono/db/schema.ts
+++ b/hono/db/schema.ts
@@ -139,6 +139,19 @@ export const users = sqliteTable("users", {
   createdAt: text("created_at").default(sql`(CURRENT_TIMESTAMP)`),
 });
 
+export const userFeatureFlags = sqliteTable(
+  "user_feature_flags",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userEmail: text("user_email").notNull(),
+    flagKey: text("flag_key").notNull(),
+    flagValue: text("flag_value").notNull(),
+    grantedBy: text("granted_by").notNull(),
+    createdAt: text("created_at").default(sql`(CURRENT_TIMESTAMP)`),
+  },
+  (table) => [uniqueIndex("user_feature_flags_email_key_unique").on(table.userEmail, table.flagKey)],
+);
+
 export const pendingRegistrations = sqliteTable(
   "pending_registrations",
   {

--- a/hono/routes/siteAdmin.ts
+++ b/hono/routes/siteAdmin.ts
@@ -1,0 +1,108 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { SiteAdminPage } from "../components/SiteAdminPage.js";
+import { getDb, users } from "../db/index.js";
+import { deleteUserFeatureFlag, getAllFeatureFlagsGroupedByUser, setUserFeatureFlag } from "../db/queries/index.js";
+import type { Env } from "../types.js";
+
+const VALID_FLAGS: Record<string, (value: string) => boolean> = {
+  maxTotalUploadBytes: (v) => {
+    const n = Number(v);
+    return Number.isFinite(n) && Number.isInteger(n) && n > 0;
+  },
+};
+
+async function listUsersWithFlags(db: ReturnType<typeof getDb>) {
+  const [allUsers, flagsByUser] = await Promise.all([
+    db.select({ email: users.email, name: users.name }).from(users),
+    getAllFeatureFlagsGroupedByUser(db),
+  ]);
+
+  return allUsers.map((u) => ({
+    email: u.email,
+    name: u.name,
+    flags: flagsByUser.get(u.email) ?? [],
+  }));
+}
+
+const siteAdminRoute = new Hono<Env>();
+
+siteAdminRoute.get("/site-admin", async (c) => {
+  try {
+    const user = c.get("user");
+    const db = getDb(c.env.DB);
+    const usersWithFlags = await listUsersWithFlags(db);
+    return c.html(`<!DOCTYPE html>${await SiteAdminPage(user, usersWithFlags)}`);
+  } catch (error) {
+    console.error("Error rendering site admin page:", error);
+    return c.json({ error: "Failed to load site admin" }, 500);
+  }
+});
+
+siteAdminRoute.get("/site-admin/api/users", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const usersWithFlags = await listUsersWithFlags(db);
+    return c.json({ users: usersWithFlags });
+  } catch (error) {
+    console.error("Error fetching users:", error);
+    return c.json({ error: "Failed to fetch users" }, 500);
+  }
+});
+
+siteAdminRoute.put("/site-admin/api/users/:email/flags/:key", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const admin = c.get("user");
+    const email = c.req.param("email");
+    const flagKey = c.req.param("key");
+
+    const validator = VALID_FLAGS[flagKey];
+    if (!validator) {
+      return c.json({ error: `Unknown flag key: ${flagKey}` }, 400);
+    }
+
+    const body = await c.req.json();
+    const flagValue = body.value;
+
+    if (typeof flagValue !== "string" || flagValue.trim() === "") {
+      return c.json({ error: "value is required and must be a non-empty string" }, 400);
+    }
+
+    if (!validator(flagValue.trim())) {
+      return c.json({ error: `Invalid value for ${flagKey}` }, 400);
+    }
+
+    const [existingUser] = await db.select({ email: users.email }).from(users).where(eq(users.email, email));
+    if (!existingUser) {
+      return c.json({ error: "User not found" }, 404);
+    }
+
+    await setUserFeatureFlag(db, email, flagKey, flagValue.trim(), admin.email);
+
+    return c.json({ message: "Flag set" });
+  } catch (error) {
+    console.error("Error setting feature flag:", error);
+    return c.json({ error: "Failed to set flag" }, 500);
+  }
+});
+
+siteAdminRoute.delete("/site-admin/api/users/:email/flags/:key", async (c) => {
+  try {
+    const db = getDb(c.env.DB);
+    const email = c.req.param("email");
+    const flagKey = c.req.param("key");
+
+    const deleted = await deleteUserFeatureFlag(db, email, flagKey);
+    if (!deleted) {
+      return c.json({ error: "Flag not found" }, 404);
+    }
+
+    return c.json({ message: "Flag removed" });
+  } catch (error) {
+    console.error("Error deleting feature flag:", error);
+    return c.json({ error: "Failed to delete flag" }, 500);
+  }
+});
+
+export { siteAdminRoute };

--- a/hono/routes/uploads.test.ts
+++ b/hono/routes/uploads.test.ts
@@ -76,6 +76,14 @@ function setupQuotaMocks(channelUsageBytes = 0, dmUsageBytes = 0) {
   });
 }
 
+function setupFeatureFlagMock(flagValue: string | null = null) {
+  mockSelect.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(flagValue ? [{ flagValue }] : []),
+    }),
+  });
+}
+
 function createTestFile(name: string, type: string, sizeBytes: number): File {
   const buffer = new ArrayBuffer(sizeBytes);
   return new File([buffer], name, { type });
@@ -97,6 +105,7 @@ describe("Upload API endpoint", () => {
     setupWorkspaceMocks();
     setupChannelMocks();
     setupQuotaMocks();
+    setupFeatureFlagMock();
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
 
@@ -268,6 +277,7 @@ describe("Upload API endpoint", () => {
     setupChannelMocks();
     const almostFullUsage = 10 * 1024 * 1024 * 1024 - 512;
     setupQuotaMocks(almostFullUsage, 0);
+    setupFeatureFlagMock();
 
     const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
     const file = createTestFile("photo.jpg", "image/jpeg", 1024);
@@ -284,6 +294,7 @@ describe("Upload API endpoint", () => {
     setupWorkspaceMocks();
     setupChannelMocks();
     setupQuotaMocks(5 * 1024 * 1024 * 1024, 0);
+    setupFeatureFlagMock();
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
 
@@ -300,6 +311,7 @@ describe("Upload API endpoint", () => {
     setupChannelMocks();
     const maxMinusFileSize = 10 * 1024 * 1024 * 1024 - 1024;
     setupQuotaMocks(maxMinusFileSize, 0);
+    setupFeatureFlagMock();
 
     mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
 
@@ -315,6 +327,7 @@ describe("Upload API endpoint", () => {
     setupWorkspaceMocks();
     setupChannelMocks();
     setupQuotaMocks(6 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024);
+    setupFeatureFlagMock();
 
     const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
     const file = createTestFile("photo.jpg", "image/jpeg", 1024);
@@ -325,6 +338,22 @@ describe("Upload API endpoint", () => {
     const body = (await response.json()) as { error: string };
     expect(body.error).toContain("Storage quota exceeded");
     expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("should use custom upload limit from feature flag", async () => {
+    setupWorkspaceMocks();
+    setupChannelMocks();
+    setupQuotaMocks(10 * 1024 * 1024 * 1024, 0);
+    setupFeatureFlagMock(String(20 * 1024 * 1024 * 1024));
+
+    mockPut.mockResolvedValueOnce({ key: "default/1/test.jpg" });
+
+    const { app } = createTestApp({ authenticatedUser, storageMock: createStorageMock() });
+    const file = createTestFile("photo.jpg", "image/jpeg", 1024);
+    const request = createUploadRequest(file, "1");
+    const response = await app.request(request);
+    expect(response.status).toBe(200);
+    expect(mockPut).toHaveBeenCalledOnce();
   });
 });
 

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -3,6 +3,7 @@ import { getDb } from "../db/index.js";
 import {
   getChannelInWorkspace,
   getConversationForParticipant,
+  getUserFeatureFlag,
   getUserTotalUploadSize,
   isChannelMember,
 } from "../db/queries/index.js";
@@ -92,8 +93,12 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     }
 
     const currentUsage = await getUserTotalUploadSize(db, user.email);
-    if (currentUsage + file.size > MAX_TOTAL_UPLOAD_SIZE) {
-      return c.json({ error: "Storage quota exceeded. Maximum total upload size is 10 GB" }, 413);
+    const customLimit = await getUserFeatureFlag(db, user.email, "maxTotalUploadBytes");
+    const parsedCustomLimit = customLimit ? parsePositiveInt(customLimit) : null;
+    const effectiveLimit = parsedCustomLimit ?? MAX_TOTAL_UPLOAD_SIZE;
+    if (currentUsage + file.size > effectiveLimit) {
+      const limitInGb = Math.round(effectiveLimit / (1024 * 1024 * 1024));
+      return c.json({ error: `Storage quota exceeded. Maximum total upload size is ${limitInGb} GB` }, 413);
     }
 
     await c.env.STORAGE.put(key, file.stream(), {

--- a/hono/routes/uploads.ts
+++ b/hono/routes/uploads.ts
@@ -11,6 +11,18 @@ import { getWorkspace } from "../helpers/getWorkspace.js";
 import { parsePositiveInt } from "../helpers/parsePositiveInt.js";
 import type { Env } from "../types.js";
 
+const BYTES_PER_MB = 1024 * 1024;
+const BYTES_PER_GB = 1024 * BYTES_PER_MB;
+
+function formatUploadLimit(bytes: number): string {
+  if (bytes >= BYTES_PER_GB) {
+    const gb = bytes / BYTES_PER_GB;
+    const rounded = Math.round(gb * 10) / 10;
+    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)} GB`;
+  }
+  return `${Math.ceil(bytes / BYTES_PER_MB)} MB`;
+}
+
 const MAX_FILE_SIZE = 25 * 1024 * 1024;
 
 const MAX_TOTAL_UPLOAD_SIZE = 10 * 1024 * 1024 * 1024;
@@ -97,8 +109,10 @@ uploadsRoute.post("/w/:slug/api/upload", async (c) => {
     const parsedCustomLimit = customLimit ? parsePositiveInt(customLimit) : null;
     const effectiveLimit = parsedCustomLimit ?? MAX_TOTAL_UPLOAD_SIZE;
     if (currentUsage + file.size > effectiveLimit) {
-      const limitInGb = Math.round(effectiveLimit / (1024 * 1024 * 1024));
-      return c.json({ error: `Storage quota exceeded. Maximum total upload size is ${limitInGb} GB` }, 413);
+      return c.json(
+        { error: `Storage quota exceeded. Maximum total upload size is ${formatUploadLimit(effectiveLimit)}` },
+        413,
+      );
     }
 
     await c.env.STORAGE.put(key, file.stream(), {

--- a/hono/static/siteAdmin.ts
+++ b/hono/static/siteAdmin.ts
@@ -1,0 +1,62 @@
+(() => {
+  document.addEventListener("click", async (e: Event) => {
+    const target = e.target as HTMLElement;
+
+    if (target.classList.contains("set-flag-button")) {
+      const email = target.dataset.email;
+      if (!email) return;
+
+      const row = target.closest("tr");
+      if (!row) return;
+
+      const select = row.querySelector(".flag-key-select") as HTMLSelectElement | null;
+      const input = row.querySelector(".flag-value-input") as HTMLInputElement | null;
+      if (!select || !input) return;
+
+      const flagKey = select.value;
+      const flagValue = input.value.trim();
+      if (!flagValue) {
+        alert("Please enter a value.");
+        return;
+      }
+
+      const response = await fetch(
+        `/site-admin/api/users/${encodeURIComponent(email)}/flags/${encodeURIComponent(flagKey)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ value: flagValue }),
+        },
+      );
+
+      if (response.ok) {
+        window.location.reload();
+      } else {
+        const body = (await response.json()) as { error?: string };
+        alert(body.error || "Failed to set flag");
+      }
+    }
+
+    if (target.classList.contains("remove-flag-button")) {
+      const email = target.dataset.email;
+      const flagKey = target.dataset.flagKey;
+      if (!email || !flagKey) return;
+
+      if (!confirm(`Remove flag "${flagKey}" from ${email}?`)) return;
+
+      const response = await fetch(
+        `/site-admin/api/users/${encodeURIComponent(email)}/flags/${encodeURIComponent(flagKey)}`,
+        {
+          method: "DELETE",
+        },
+      );
+
+      if (response.ok) {
+        window.location.reload();
+      } else {
+        const body = (await response.json()) as { error?: string };
+        alert(body.error || "Failed to remove flag");
+      }
+    }
+  });
+})();

--- a/hono/testApp.ts
+++ b/hono/testApp.ts
@@ -42,6 +42,9 @@ export function createTestApp(options?: {
     if (!c.env.RESEND_FROM_EMAIL) {
       c.env.RESEND_FROM_EMAIL = "noreply@test.com";
     }
+    if (!c.env.SITE_ADMIN_EMAIL) {
+      c.env.SITE_ADMIN_EMAIL = "";
+    }
     await next();
   };
 

--- a/hono/types.ts
+++ b/hono/types.ts
@@ -50,6 +50,7 @@ export type Bindings = {
   E2E_GMAIL_ACCOUNT: string;
   RESEND_API_KEY: string;
   RESEND_FROM_EMAIL: string;
+  SITE_ADMIN_EMAIL: string;
 };
 
 export type Variables = {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,6 +27,7 @@ new_sqlite_classes = ["ChatRoom"]
 
 [vars]
 NODE_ENV = "development"
+SITE_ADMIN_EMAIL = ""
 
 [env.production]
 routes = [

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,7 +27,6 @@ new_sqlite_classes = ["ChatRoom"]
 
 [vars]
 NODE_ENV = "development"
-SITE_ADMIN_EMAIL = ""
 
 [env.production]
 routes = [


### PR DESCRIPTION
## Summary

mlack currently has workspace-level admins but no site-wide admin concept. This PR adds a site admin view where a designated person (identified by `SITE_ADMIN_EMAIL` env var) can manage per-user feature flags -- starting with overriding the default 10 GB upload limit on a per-user basis.

The approach uses a flexible key-value `user_feature_flags` table so new flag types can be added without schema migrations. The admin UI lives at `/site-admin`, fully separate from the existing workspace admin at `/w/:slug/admin/*`.

## Included Changes

**New files (10):**
- `hono/auth/requireSiteAdmin.ts` -- middleware gated by `SITE_ADMIN_EMAIL` with case-insensitive email comparison and misconfiguration logging
- `hono/auth/requireSiteAdmin.test.ts` -- middleware tests (401, 403, success cases)
- `hono/db/queries/userFeatureFlags.ts` -- DB query helpers (get/set/delete flags + bulk fetch)
- `hono/db/queries/userFeatureFlags.test.ts` -- query layer tests
- `hono/routes/siteAdmin.ts` -- route handlers with server-side flag key allowlist, value validation, and user existence checks
- `hono/components/SiteAdminPage.tsx` -- admin dashboard page component
- `hono/components/SiteAdminPage.css` -- styles
- `hono/static/siteAdmin.ts` -- client-side JS for flag management (row-scoped DOM queries, no CSS selector injection)
- `hono/db/migrations/0006_add_user_feature_flags.sql` -- migration for the new table

**Modified files (8):**
- `hono/db/schema.ts` -- added `userFeatureFlags` table definition
- `hono/types.ts` -- added `SITE_ADMIN_EMAIL` to `Bindings`
- `hono/app.tsx` -- registered site admin routes + middleware
- `hono/routes/uploads.ts` -- upload quota now checks `maxTotalUploadBytes` feature flag per user, with safe parsing via `parsePositiveInt` (invalid values fall back to default)
- `hono/routes/uploads.test.ts` -- added test for custom upload limit override
- `hono/db/queries/index.ts` -- re-exported new query functions
- `hono/testApp.ts` -- added `SITE_ADMIN_EMAIL` to test environment
- `wrangler.toml` -- added `SITE_ADMIN_EMAIL` var placeholder

## Pre-deploy Checklist

- [ ] CI checks pass on `main`
- [x] Database migrations reviewed (if applicable)
- [ ] New secrets/env vars configured in Cloudflare (if applicable)
  - `SITE_ADMIN_EMAIL` must be set in production to enable the admin view
- [x] No breaking changes to Durable Objects state

## Rollback Plan

Revert the merge commit. The new `user_feature_flags` table is additive and does not affect existing functionality if the feature is unused. The upload route falls back to the default 10 GB limit when no flag is set, so reverting is safe without data migration.