### PR TITLE
chore: ignore Eclipse .classpath in Android project

### DIFF
--- a/mobile/android/.gitignore
+++ b/mobile/android/.gitignore
@@ -45,6 +45,7 @@ captures/
 # Eclipse
 .project
 .settings/
+.classpath
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.


### PR DESCRIPTION
`.classpath` is an Eclipse/Buildship-generated IDE file that sits alongside `.project` and `.settings/`, which `mobile/android/.gitignore` already ignores. Adding `.classpath` to the same block so it stops showing up as an untracked file.

No code changes.